### PR TITLE
feat: add standalone CLI and test suite

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Standalone CLI for slop-guard.  Zero external dependencies.
+
+Usage:
+    python cli.py README.md [file2.md ...]
+    cat draft.md | python cli.py
+    python cli.py --json README.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from slop_guard import HYPERPARAMETERS, _analyze
+
+# -- colors (when tty) -----------------------------------------------------
+
+_BAND_COLORS = {
+    "clean": "\033[32m",
+    "light": "\033[33m",
+    "moderate": "\033[38;5;208m",
+    "heavy": "\033[31m",
+    "saturated": "\033[91m",
+}
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+
+
+def _print_result(result: dict[str, Any], label: str) -> None:
+    color = sys.stderr.isatty()
+    score = result["score"]
+    band = result["band"]
+    words = result["word_count"]
+
+    bc = _BAND_COLORS.get(band, "") if color else ""
+    r = _RESET if color else ""
+    b = _BOLD if color else ""
+    d = _DIM if color else ""
+
+    print(
+        f"\n{b}{label}{r}  {bc}{score}/100 {band}{r}  {d}({words} words){r}",
+        file=sys.stderr,
+    )
+
+    for v in result.get("violations", []):
+        pen = v.get("penalty", 0)
+        rule = v.get("rule", "")
+        match = v.get("match", "")
+        print(f"  {bc}{pen:+d}{r}  {rule}: {match}", file=sys.stderr)
+
+    advice = result.get("advice", [])
+    if advice:
+        print(f"\n{b}Advice:{r}", file=sys.stderr)
+        for a in advice:
+            print(f"  • {a}", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="slop-guard", description="Detect AI slop patterns in prose."
+    )
+    parser.add_argument("files", nargs="*", help="Files to analyze (stdin if omitted)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON to stdout")
+    args = parser.parse_args()
+
+    if not args.files and sys.stdin.isatty():
+        parser.print_help(sys.stderr)
+        sys.exit(2)
+
+    targets: list[tuple[str, str]] = []
+    exit_code = 0
+
+    if args.files:
+        for fp in args.files:
+            p = Path(fp)
+            if not p.is_file():
+                print(f"slop-guard: {fp}: not found", file=sys.stderr)
+                exit_code = 2
+                continue
+            targets.append((fp, p.read_text(encoding="utf-8")))
+    else:
+        targets.append(("stdin", sys.stdin.read()))
+
+    results = []
+    for label, text in targets:
+        result = _analyze(text, HYPERPARAMETERS)
+        result["file"] = label
+        results.append(result)
+        if not args.json:
+            _print_result(result, label)
+
+    if args.json:
+        out = results[0] if len(results) == 1 else results
+        print(json.dumps(out, indent=2))
+
+    if not exit_code and any(r["band"] not in ("clean", "light") for r in results):
+        exit_code = 1
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_slop_guard.py
+++ b/test_slop_guard.py
@@ -1,0 +1,224 @@
+"""Tests for slop-guard analysis engine and CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from slop_guard import HYPERPARAMETERS, _analyze
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+CLEAN_PROSE = textwrap.dedent("""\
+    The compiler translates source code into machine instructions. It
+    starts by tokenizing the input stream, breaking raw characters into
+    meaningful symbols that a parser then assembles into an abstract
+    syntax tree.
+
+    Why bother with so many stages? Each one narrows the problem. The
+    tree mirrors grammatical structure but says nothing about registers
+    or calling conventions. Later passes lower it into a flat
+    intermediate form where constant folding and dead-code elimination
+    can operate without worrying about syntax.
+
+    Register allocation is the hard part. The allocator must map an
+    unbounded set of virtual names onto a handful of physical registers,
+    spilling to the stack when it runs out. Graph coloring works, but
+    linear scan is faster for JIT compilers that need answers quickly.
+
+    After allocation the backend emits relocatable object code. A linker
+    glues the pieces together, resolves symbols, and writes the final
+    executable. Done.
+""")
+
+SLOPPY_PROSE = textwrap.dedent("""\
+    It's worth noting that this groundbreaking, revolutionary journey
+    delves into the comprehensive landscape of innovation. Furthermore,
+    this seamless, holistic approach leverages cutting-edge technology to
+    unlock unprecedented potential. As an AI language model, I can
+    certainly help you navigate this pivotal paradigm shift. Let me know
+    if you'd like me to elaborate further on this crucial tapestry of
+    transformative change. The trajectory of this multifaceted odyssey
+    underscores the paramount importance of meticulous orchestration.
+""")
+
+CLI = [sys.executable, str(Path(__file__).with_name("cli.py"))]
+
+
+# ---------------------------------------------------------------------------
+# Engine: basic scoring
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeBasics:
+    def test_short_text_is_clean(self):
+        result = _analyze("Hello world.", HYPERPARAMETERS)
+        assert result["score"] == 100
+        assert result["band"] == "clean"
+        assert result["violations"] == []
+
+    def test_empty_string_is_clean(self):
+        result = _analyze("", HYPERPARAMETERS)
+        assert result["score"] == 100
+        assert result["band"] == "clean"
+
+    def test_clean_prose_scores_high(self):
+        result = _analyze(CLEAN_PROSE, HYPERPARAMETERS)
+        assert result["score"] >= HYPERPARAMETERS.band_clean_min
+        assert result["band"] == "clean"
+
+    def test_sloppy_prose_scores_low(self):
+        result = _analyze(SLOPPY_PROSE, HYPERPARAMETERS)
+        assert result["score"] < HYPERPARAMETERS.band_moderate_min
+        assert result["band"] in ("heavy", "saturated")
+        assert len(result["violations"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Engine: individual rule detection
+# ---------------------------------------------------------------------------
+
+
+class TestRuleDetection:
+    def test_slop_words_detected(self):
+        text = "We must delve into this comprehensive and pivotal matter carefully and with attention to the details that matter most in practice."
+        result = _analyze(text, HYPERPARAMETERS)
+        slop_rules = [v["rule"] for v in result["violations"]]
+        assert "slop_word" in slop_rules
+        slop_matches = {
+            v["match"] for v in result["violations"] if v["rule"] == "slop_word"
+        }
+        assert "delve" in slop_matches
+        assert "comprehensive" in slop_matches
+        assert "pivotal" in slop_matches
+
+    def test_slop_phrase_detected(self):
+        text = "It's worth noting that the system performs well under load during normal weekday traffic patterns and during scheduled batch runs."
+        result = _analyze(text, HYPERPARAMETERS)
+        phrase_matches = [v for v in result["violations"] if v["rule"] == "slop_phrase"]
+        assert any("it's worth noting" in v["match"] for v in phrase_matches)
+
+    def test_ai_disclosure_detected(self):
+        text = "As an AI language model, I cannot provide medical advice but I can share general information about health topics for educational use."
+        result = _analyze(text, HYPERPARAMETERS)
+        ai_rules = [v for v in result["violations"] if v["rule"] == "ai_disclosure"]
+        assert len(ai_rules) > 0
+
+    def test_bold_header_structural(self):
+        text = (
+            "**Speed.** The system is fast.\n\n"
+            "**Scale.** It handles millions.\n\n"
+            "**Safety.** Nothing breaks.\n\n"
+            "These three properties define the architecture."
+        )
+        result = _analyze(text, HYPERPARAMETERS)
+        structural = [
+            v for v in result["violations"] if v["match"] == "bold_header_explanation"
+        ]
+        assert len(structural) == 1
+
+    def test_bullet_run_structural(self):
+        text = textwrap.dedent("""\
+            Consider the following points about system design and architecture:
+
+            - First item about databases
+            - Second item about caching
+            - Third item about queues
+            - Fourth item about logging
+            - Fifth item about monitoring
+            - Sixth item about alerting
+            - Seventh item about deployment
+        """)
+        result = _analyze(text, HYPERPARAMETERS)
+        bullet_violations = [
+            v for v in result["violations"] if v["match"] == "excessive_bullets"
+        ]
+        assert len(bullet_violations) > 0
+
+    def test_advice_is_populated(self):
+        result = _analyze(SLOPPY_PROSE, HYPERPARAMETERS)
+        assert len(result["advice"]) > 0
+
+    def test_word_count_is_accurate(self):
+        text = "one two three four five"
+        result = _analyze(text, HYPERPARAMETERS)
+        assert result["word_count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Engine: band boundaries
+# ---------------------------------------------------------------------------
+
+
+class TestBands:
+    def test_score_100_is_clean(self):
+        r = _analyze("Short.", HYPERPARAMETERS)
+        assert r["band"] == "clean"
+
+    def test_band_names_are_valid(self):
+        r = _analyze(SLOPPY_PROSE, HYPERPARAMETERS)
+        assert r["band"] in ("clean", "light", "moderate", "heavy", "saturated")
+
+
+# ---------------------------------------------------------------------------
+# CLI: integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_clean_file_exit_0(self, tmp_path):
+        f = tmp_path / "clean.md"
+        f.write_text(CLEAN_PROSE)
+        proc = subprocess.run([*CLI, str(f)], capture_output=True, text=True)
+        assert proc.returncode == 0
+        assert "clean" in proc.stderr
+
+    def test_sloppy_file_exit_1(self, tmp_path):
+        f = tmp_path / "slop.md"
+        f.write_text(SLOPPY_PROSE)
+        proc = subprocess.run([*CLI, str(f)], capture_output=True, text=True)
+        assert proc.returncode == 1
+
+    def test_missing_file_exit_2(self):
+        proc = subprocess.run(
+            [*CLI, "/no/such/file.md"], capture_output=True, text=True
+        )
+        assert proc.returncode == 2
+        assert "not found" in proc.stderr
+
+    def test_json_flag_outputs_valid_json(self, tmp_path):
+        f = tmp_path / "doc.md"
+        f.write_text(CLEAN_PROSE)
+        proc = subprocess.run([*CLI, "--json", str(f)], capture_output=True, text=True)
+        data = json.loads(proc.stdout)
+        assert "score" in data
+        assert "band" in data
+        assert "violations" in data
+
+    def test_stdin_pipe(self):
+        proc = subprocess.run(
+            CLI,
+            input=CLEAN_PROSE,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0
+        assert "clean" in proc.stderr
+
+    def test_multiple_files(self, tmp_path):
+        clean = tmp_path / "clean.md"
+        clean.write_text(CLEAN_PROSE)
+        slop = tmp_path / "slop.md"
+        slop.write_text(SLOPPY_PROSE)
+        proc = subprocess.run(
+            [*CLI, str(clean), str(slop)], capture_output=True, text=True
+        )
+        # exit 1 because at least one file is moderate+
+        assert proc.returncode == 1
+        assert "clean.md" in proc.stderr
+        assert "slop.md" in proc.stderr


### PR DESCRIPTION
## Summary

- Lazy-load the `mcp` import so `slop_guard.py` is importable as a plain Python module (no `mcp` dependency required at import time)
- Add `cli.py`, a zero-dependency CLI wrapper: `python cli.py README.md`
- Add `test_slop_guard.py` with 19 pytest cases covering the analysis engine and CLI

## Motivation

The analysis engine (`_analyze`) is self-contained and useful outside the MCP server context. Before this change, `from slop_guard import _analyze` fails without `mcp` installed because `FastMCP` is imported and instantiated at module scope.

Moving the MCP setup into `if __name__ == "__main__"` fixes this with minimal diff to the original file.

## CLI usage

```
python cli.py README.md              # colored terminal output
python cli.py --json draft.md        # machine-readable JSON to stdout
cat essay.md | python cli.py         # stdin
python cli.py file1.md file2.md      # multiple files
```

Exit codes: 0 = clean/light, 1 = moderate or worse, 2 = missing file.

## Test coverage

```
pytest test_slop_guard.py -v    # 19 tests, ~0.4s
```

Tests cover: short-text bypass, clean/sloppy scoring, individual rule detection (slop words, slop phrases, AI disclosure, bold-header structure, bullet runs), band classification, and CLI integration (file args, stdin, --json, exit codes, missing files, multi-file).

## What changed in `slop_guard.py`

Two edits, no behavioral change to the MCP server:

1. Removed the top-level `from mcp.server.fastmcp import FastMCP` import
2. Moved `FastMCP` import + server setup + `mcp_server.run()` inside `if __name__ == "__main__"`