### PR TITLE
docs: add agent setup sections for Claude Code and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ args = ["slop-guard"]
 
 If you want a fixed release, pin it in `args`, for example: `["slop-guard==0.1.0"]`.
 
-## Installation (Optional)
+## Local Installation (Optional)
 
 Requires [uv](https://docs.astral.sh/uv/).
 


### PR DESCRIPTION
## Description
- Rename the README integration section from "Wire into Claude Code" to "Add to Your Agent".
- Split integration instructions into explicit subsections for:
  - Claude Code (`.mcp.json`)
  - Codex (`~/.codex/config.toml`)
- Keep the existing `uvx slop-guard` command and version pinning guidance unchanged.

## Why?
- Users are running slop-guard from multiple agent clients, not only Claude Code.
- A neutral top-level section plus client-specific snippets makes setup clearer and avoids tool-specific ambiguity.

## Usage / Demonstration
- Claude Code users can copy the `.mcp.json` block under "Add to Your Agent" -> "Claude Code".
- Codex users can copy the `config.toml` block under "Add to Your Agent" -> "Codex".

## Test Plan
- Manually reviewed rendered README markdown in repository context.
- Verified command snippets remain consistent with current packaging and release flow (`uvx slop-guard`, optional version pin).
