### PR TITLE
feat(cli): update sg input handling, concise mode, and streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,21 +63,21 @@ sg README.md
 ### Usage
 
 ```
-sg [OPTIONS] [FILE ...]
+sg [OPTIONS] INPUT [INPUT ...]
 ```
 
-When no files are given (or `-` is passed), `sg` reads from stdin:
+`sg` requires at least one input. Each input can be a file path, `-` for stdin, or quoted inline prose text:
 
 ```bash
-cat essay.txt | sg
+sg "This is some test text"
 echo "This is a crucial paradigm shift." | sg -
 ```
 
-Lint multiple files at once:
+Lint multiple files at once (shell-level glob expansion):
 
 ```bash
 sg docs/*.md README.md
-sg -g "src/**/*.md" -g "docs/**/*.md"
+sg path/**/*.md
 ```
 
 ### Options
@@ -88,8 +88,8 @@ sg -g "src/**/*.md" -g "docs/**/*.md"
 | `-v`, `--verbose` | Show individual violations and advice |
 | `-q`, `--quiet` | Only print sources that fail the threshold |
 | `-t SCORE`, `--threshold SCORE` | Minimum passing score (0-100). Exit 1 if any file scores below this |
-| `-c`, `--counts` | Show per-rule hit counts in the summary line |
-| `-g PATTERN`, `--glob PATTERN` | Additional glob patterns to expand (repeatable) |
+| `-c`, `--concise` | Print only numeric score output |
+| `--counts` | Show per-rule hit counts in the summary line |
 
 ### Examples
 
@@ -97,6 +97,9 @@ sg -g "src/**/*.md" -g "docs/**/*.md"
 # One-line summary per file
 sg draft.md
 # => draft.md: 72/100 [light] (1843 words) *
+
+# Concise output (score only)
+sg -c draft.md
 
 # Verbose output with violations and advice
 sg -v draft.md

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,93 @@
+"""Tests for ``sg`` CLI argument and output behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from slop_guard import cli
+
+
+def _fake_result(source: str, score: int = 75) -> dict[str, object]:
+    """Build a minimal analysis payload used in CLI tests."""
+    return {
+        "source": source,
+        "score": score,
+        "band": "light",
+        "word_count": 4,
+        "violations": [],
+        "advice": [],
+        "counts": {},
+    }
+
+
+def test_requires_at_least_one_input(capsys: pytest.CaptureFixture[str]) -> None:
+    """Running ``sg`` with no args should exit with an argument error."""
+    with pytest.raises(SystemExit) as raised:
+        cli.cli_main([])
+
+    assert raised.value.code == cli.EXIT_ERROR
+    assert "the following arguments are required: INPUT" in capsys.readouterr().err
+
+
+def test_accepts_inline_text_input(capsys: pytest.CaptureFixture[str]) -> None:
+    """Inline quoted text should be analyzed as prose input."""
+    exit_code = cli.cli_main(["This is some test text"])
+    captured = capsys.readouterr()
+
+    assert exit_code == cli.EXIT_OK
+    assert captured.err == ""
+    assert captured.out.startswith("<text:1>: ")
+    assert "/100 [" in captured.out
+
+
+def test_concise_mode_prints_score_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """Concise mode should output only a numeric score."""
+    exit_code = cli.cli_main(["-c", "This is some test text"])
+    captured = capsys.readouterr()
+
+    assert exit_code == cli.EXIT_OK
+    assert captured.err == ""
+    assert captured.out.strip().isdigit()
+
+
+def test_streams_file_results_as_each_file_finishes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Non-JSON output should emit per-file results in processing order."""
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    first.write_text("alpha", encoding="utf-8")
+    second.write_text("beta", encoding="utf-8")
+
+    events: list[str] = []
+
+    def fake_analyze_file(path: Path, _hyperparameters: object) -> dict[str, object]:
+        events.append(f"analyze:{path.name}")
+        return _fake_result(str(path))
+
+    def fake_emit_result(result: dict[str, object], _args: object) -> None:
+        events.append(f"emit:{result['source']}")
+
+    monkeypatch.setattr(cli, "_analyze_file", fake_analyze_file)
+    monkeypatch.setattr(cli, "_emit_result", fake_emit_result)
+
+    exit_code = cli.cli_main([str(first), str(second)])
+
+    assert exit_code == cli.EXIT_OK
+    assert events == [
+        f"analyze:{first.name}",
+        f"emit:{first}",
+        f"analyze:{second.name}",
+        f"emit:{second}",
+    ]
+
+
+def test_rejects_legacy_glob_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """The removed ``--glob`` option should now fail argument parsing."""
+    with pytest.raises(SystemExit) as raised:
+        cli.cli_main(["--glob", "*.md"])
+
+    assert raised.value.code == cli.EXIT_ERROR
+    assert "unrecognized arguments: --glob" in capsys.readouterr().err


### PR DESCRIPTION
## Description
- Require at least one positional input instead of implicit stdin fallback.
- Support quoted inline text arguments such as `sg "This is some test text"`.
- Add concise mode via `-c/--concise` that prints only score values.
- Stream non-JSON output per input as each item is processed.
- Remove `--glob` and internal glob expansion, relying on shell globbing.
- Add pytest coverage for all new CLI behaviors.

## Why?
- Make CLI behavior explicit and predictable while improving ergonomics for quick ad-hoc checks and larger multi-file runs.

## Usage / Demonstration
- `sg "This is some test text"`
- `sg -c README.md`
- `sg docs/**/*.md`

## Test Plan
- `uv run --with pytest pytest`
