### PR TITLE
perf: Reduce single-rule compute time by up to 14x

### DIFF
--- a/src/slop_guard/rules/sentence_level/setup_resolution_rule.py
+++ b/src/slop_guard/rules/sentence_level/setup_resolution_rule.py
@@ -65,6 +65,13 @@ class SetupResolutionRule(Rule[SetupResolutionRuleConfig]):
 
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply both setup-resolution regex forms."""
+        if (
+            "n't" not in document.lower_text
+            and "not" not in document.word_token_set_lower
+            and "cannot" not in document.word_token_set_lower
+        ):
+            return RuleResult()
+
         violations: list[Violation] = []
         advice: list[str] = []
         count = 0

--- a/src/slop_guard/rules/sentence_level/tone_marker_rule.py
+++ b/src/slop_guard/rules/sentence_level/tone_marker_rule.py
@@ -27,19 +27,32 @@ from slop_guard.analysis import AnalysisDocument, RuleResult, Violation, context
 
 from slop_guard.rules.base import Rule, RuleConfig, RuleLevel
 
-_META_COMM_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"would you like", re.IGNORECASE),
-    re.compile(r"let me know if", re.IGNORECASE),
-    re.compile(r"as mentioned", re.IGNORECASE),
-    re.compile(r"i hope this", re.IGNORECASE),
-    re.compile(r"feel free to", re.IGNORECASE),
-    re.compile(r"don't hesitate to", re.IGNORECASE),
+_META_COMM_LITERALS: tuple[str, ...] = (
+    "would you like",
+    "let me know if",
+    "as mentioned",
+    "i hope this",
+    "feel free to",
+    "don't hesitate to",
+)
+_META_COMM_LITERAL_LENGTHS: tuple[int, ...] = tuple(
+    len(phrase) for phrase in _META_COMM_LITERALS
+)
+_META_COMM_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(re.escape(phrase), re.IGNORECASE) for phrase in _META_COMM_LITERALS
 )
 
-_FALSE_NARRATIVITY_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"then something interesting happened", re.IGNORECASE),
-    re.compile(r"this is where things get interesting", re.IGNORECASE),
-    re.compile(r"that's when everything changed", re.IGNORECASE),
+_FALSE_NARRATIVITY_LITERALS: tuple[str, ...] = (
+    "then something interesting happened",
+    "this is where things get interesting",
+    "that's when everything changed",
+)
+_FALSE_NARRATIVITY_LITERAL_LENGTHS: tuple[int, ...] = tuple(
+    len(phrase) for phrase in _FALSE_NARRATIVITY_LITERALS
+)
+_FALSE_NARRATIVITY_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(re.escape(phrase), re.IGNORECASE)
+    for phrase in _FALSE_NARRATIVITY_LITERALS
 )
 
 _SENTENCE_OPENER_PATTERNS: tuple[re.Pattern[str], ...] = (
@@ -70,68 +83,125 @@ class ToneMarkerRule(Rule[ToneMarkerRuleConfig]):
         advice: list[str] = []
         count = 0
 
-        for pattern in _META_COMM_PATTERNS:
-            for match in pattern.finditer(document.text):
-                phrase = match.group(0).lower()
-                violations.append(
-                    Violation(
-                        rule=self.name,
-                        match=phrase,
-                        context=context_around(
-                            document.text,
-                            match.start(),
-                            match.end(),
-                            width=self.config.context_window_chars,
-                        ),
-                        penalty=self.config.tone_penalty,
+        if document.text.isascii():
+            lower_text = document.lower_text
+            for index, phrase in enumerate(_META_COMM_LITERALS):
+                phrase_len = _META_COMM_LITERAL_LENGTHS[index]
+                start = 0
+                while True:
+                    hit_start = lower_text.find(phrase, start)
+                    if hit_start < 0:
+                        break
+                    hit_end = hit_start + phrase_len
+                    violations.append(
+                        Violation(
+                            rule=self.name,
+                            match=phrase,
+                            context=context_around(
+                                document.text,
+                                hit_start,
+                                hit_end,
+                                width=self.config.context_window_chars,
+                            ),
+                            penalty=self.config.tone_penalty,
+                        )
                     )
-                )
-                advice.append(
-                    f"Remove '{phrase}' \u2014 this is a direct AI tell."
-                )
-                count += 1
+                    advice.append(
+                        f"Remove '{phrase}' \u2014 this is a direct AI tell."
+                    )
+                    count += 1
+                    start = hit_end
 
-        for pattern in _FALSE_NARRATIVITY_PATTERNS:
-            for match in pattern.finditer(document.text):
-                phrase = match.group(0).lower()
-                violations.append(
-                    Violation(
-                        rule=self.name,
-                        match=phrase,
-                        context=context_around(
-                            document.text,
-                            match.start(),
-                            match.end(),
-                            width=self.config.context_window_chars,
-                        ),
-                        penalty=self.config.tone_penalty,
+            for index, phrase in enumerate(_FALSE_NARRATIVITY_LITERALS):
+                phrase_len = _FALSE_NARRATIVITY_LITERAL_LENGTHS[index]
+                start = 0
+                while True:
+                    hit_start = lower_text.find(phrase, start)
+                    if hit_start < 0:
+                        break
+                    hit_end = hit_start + phrase_len
+                    violations.append(
+                        Violation(
+                            rule=self.name,
+                            match=phrase,
+                            context=context_around(
+                                document.text,
+                                hit_start,
+                                hit_end,
+                                width=self.config.context_window_chars,
+                            ),
+                            penalty=self.config.tone_penalty,
+                        )
                     )
-                )
-                advice.append(
-                    f"Cut '{phrase}' \u2014 announce less, show more."
-                )
-                count += 1
+                    advice.append(
+                        f"Cut '{phrase}' \u2014 announce less, show more."
+                    )
+                    count += 1
+                    start = hit_end
+        else:
+            for pattern in _META_COMM_PATTERNS:
+                for match in pattern.finditer(document.text):
+                    phrase = match.group(0).lower()
+                    violations.append(
+                        Violation(
+                            rule=self.name,
+                            match=phrase,
+                            context=context_around(
+                                document.text,
+                                match.start(),
+                                match.end(),
+                                width=self.config.context_window_chars,
+                            ),
+                            penalty=self.config.tone_penalty,
+                        )
+                    )
+                    advice.append(
+                        f"Remove '{phrase}' \u2014 this is a direct AI tell."
+                    )
+                    count += 1
 
-        for pattern in _SENTENCE_OPENER_PATTERNS:
-            for match in pattern.finditer(document.text):
-                word = match.group(1).strip(" ,!").lower()
-                violations.append(
-                    Violation(
-                        rule=self.name,
-                        match=word,
-                        context=context_around(
-                            document.text,
-                            match.start(),
-                            match.end(),
-                            width=self.config.context_window_chars,
-                        ),
-                        penalty=self.config.sentence_opener_penalty,
+            for pattern in _FALSE_NARRATIVITY_PATTERNS:
+                for match in pattern.finditer(document.text):
+                    phrase = match.group(0).lower()
+                    violations.append(
+                        Violation(
+                            rule=self.name,
+                            match=phrase,
+                            context=context_around(
+                                document.text,
+                                match.start(),
+                                match.end(),
+                                width=self.config.context_window_chars,
+                            ),
+                            penalty=self.config.tone_penalty,
+                        )
                     )
-                )
-                advice.append(
-                    f"'{word}' as a sentence opener is an AI tell \u2014 just make the point."
-                )
-                count += 1
+                    advice.append(
+                        f"Cut '{phrase}' \u2014 announce less, show more."
+                    )
+                    count += 1
+
+        if "certainly" in document.lower_text or "absolutely" in document.lower_text:
+            for pattern in _SENTENCE_OPENER_PATTERNS:
+                for match in pattern.finditer(document.text):
+                    word = match.group(1).strip(" ,!").lower()
+                    violations.append(
+                        Violation(
+                            rule=self.name,
+                            match=word,
+                            context=context_around(
+                                document.text,
+                                match.start(),
+                                match.end(),
+                                width=self.config.context_window_chars,
+                            ),
+                            penalty=self.config.sentence_opener_penalty,
+                        )
+                    )
+                    advice.append(
+                        f"'{word}' as a sentence opener is an AI tell \u2014 just make the point."
+                    )
+                    count += 1
 
         return RuleResult(
             violations=violations,


### PR DESCRIPTION
## Description
- Optimizes the hottest rules reported by `benchmark/compute-time.py` using parity-safe fast-negative gates and ASCII literal scan paths.
- Adds cached document projections (`lower_text`, token sets, and n-gram token/id payloads) to avoid repeated recomputation across rule passes.
- Refactors phrase reuse helpers to support token-based execution and a fast repeated-prefix precheck before full n-gram expansion.
- Preserves result behavior by falling back to original regex paths when needed and keeping violation/advice ordering aligned.

## Why?
- The 10k-word compute-time benchmark was bottlenecked by repeated full-text regex passes and full n-gram expansion in no-hit cases.
- The target was to iteratively optimize the slowest rule until the slowest rule was below 1ms at 10k words while maintaining score/result parity.

## Usage / Demonstration
Run:
```bash
uv run benchmark/compute-time.py --min-words 10000 --max-words 10000 --length-mode all --repeats 9 --warmup-runs 1 --output benchmark/output/rule_compute_time_10k_final.jsonl
```
Result (mean at 10k words):
- slowest rule: `phrase_reuse` at `0.907ms`
- next: `contrast_pair` at `0.774ms`
- next: `slop_phrase` at `0.666ms`

Full-pipeline parity check versus `main` on 405 generated documents: exact JSON output parity.

## Test Plan
- `uv run --with pytest python -m pytest`
- Rule-level parity harnesses vs `main` for:
  - `slop_phrase`
  - `slop_word`
  - `phrase_reuse`
  - `tone`
  - `weasel`
  - `ai_disclosure`
  - `setup_resolution`
- Full-pipeline parity harness vs `main` over 405 generated documents (score/band/counts/violations/advice JSON lines identical).
- Final benchmark confirmation:
  - `uv run benchmark/compute-time.py --min-words 10000 --max-words 10000 --length-mode all --repeats 9 --warmup-runs 1`
