### PR TITLE
chore(release): cut v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ command = "uvx"
 args = ["slop-guard"]
 ```
 
-If you want a fixed release, pin it in `args`, for example: `["slop-guard==0.1.0"]`.
+If you want a fixed release, pin it in `args`, for example: `["slop-guard==0.2.0"]`.
 
 ## CLI
 
@@ -141,7 +141,7 @@ uv tool install slop-guard
 Pin versions for reproducibility:
 
 ```bash
-uvx slop-guard==0.1.0
+uvx slop-guard==0.2.0
 ```
 
 Upgrade an installed tool:

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -1,0 +1,54 @@
+# slop-guard v0.2.0
+
+v0.2.0 focuses on packaging, CLI ergonomics, and rule-system internals. If you are upgrading from v0.1.0, this release gives cleaner install paths, a faster pipeline on long inputs, and groundwork for trainable rules.
+
+## Install and launch
+
+slop-guard now fits standard PyPI workflows and the `uvx` execution pattern.
+
+Run without installing:
+
+```bash
+uvx slop-guard
+```
+
+Install the tool once for local reuse:
+
+```bash
+uv tool install slop-guard
+```
+
+If you need pinned behavior in scripts:
+
+```bash
+uvx slop-guard==0.2.0
+```
+
+## New `sg` CLI command
+
+The release adds `sg` as a direct command-line interface for prose linting. It supports file paths and stdin, plus inline text, JSON output, concise output, verbose diagnostics, threshold-based exit codes, and quiet mode for CI filtering.
+
+Examples:
+
+```bash
+sg draft.md
+sg -v draft.md
+sg -j docs/*.md
+echo "Sample text" | sg -
+```
+
+## Modular rule architecture for reuse
+
+The analyzer is now split into explicit rule modules by level (`word`, `sentence`, `paragraph`, and `passage`) with a shared rule registry and pipeline. This makes it easier to add, swap, or reuse rule components in new tools while preserving the same score and violation model.
+
+## Performance and memory improvements on large inputs
+
+This release reduces hot-path overhead by caching document projections that multiple rules consume, such as token streams and precomputed line flags. It also adds early prefix checks for repeated n-gram detection to avoid expensive full phrase scans when no repeat signal exists. In benchmark runs, the slowest default rule at 10k words is now under 1 ms per forward pass.
+
+## Foundation for fitted rules
+
+Rules now expose a preliminary `.fit(samples, labels)` API with typed input validation and config serialization (`to_dict` / `from_dict`). The default fitting behavior is intentionally conservative today, but the interface lays the groundwork for fitting rule configurations against labeled corpora in upcoming releases.
+
+## Upgrade notes
+
+This release keeps Python `>=3.11` and remains API-compatible at the tool level (`check_slop`, `check_slop_file`, and score payload shape). Existing MCP integrations can move to `uvx slop-guard==0.2.0` for pinned installs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slop-guard"
-version = "0.1.0"
+version = "0.2.0"
 description = "Rule-based prose linter for formulaic AI writing patterns."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -609,7 +609,7 @@ wheels = [
 
 [[package]]
 name = "slop-guard"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Description
- Cut the `v0.2.0` release from the current `main` state.
- Bump package version from `0.1.0` to `0.2.0` in `pyproject.toml` and `uv.lock`.
- Update version-pinned install examples in `README.md` to `0.2.0`.
- Add user-facing release notes in `RELEASE_NOTES_v0.2.0.md`, covering:
  - PyPI install and `uvx` usage patterns
  - `sg` CLI command support and usage modes
  - modularized rule framework for tool reuse
  - performance/memory improvements for large inputs
  - preliminary `.fit(samples, labels)` rule API for corpus-based fitting workflows

## Why?
- This prepares a tagged release branch for `v0.2.0` with explicit upgrade guidance.
- It keeps docs, package metadata, and lock metadata aligned so publish/tag checks pass.
- It gives users concrete migration/install instructions and a clear summary of what changed.

## Usage / Demonstration
- Release notes lint pass:
  - `uv run sg -v RELEASE_NOTES_v0.2.0.md`
  - Output: `RELEASE_NOTES_v0.2.0.md: 100/100 [clean] (337 words) .`
- Version resolution check:
  - `uv version --short`
  - Output: `0.2.0`
- Release tag pushed:
  - `git push origin v0.2.0`

## Test Plan
- `uv run --with pytest pytest`
- Result: `11 passed`
