### PR TITLE
feat: add per-rule example fixtures and registry-wide example validation

### DIFF
--- a/src/slop_guard/rules/base.py
+++ b/src/slop_guard/rules/base.py
@@ -88,6 +88,14 @@ class Rule(ABC, Generic[ConfigT]):
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply the rule and return violations, advice, and counter deltas."""
 
+    @abstractmethod
+    def example_violations(self) -> list[str]:
+        """Return text samples that should trigger this rule."""
+
+    @abstractmethod
+    def example_non_violations(self) -> list[str]:
+        """Return text samples that should not trigger this rule."""
+
     def fit(self, samples: list[str], labels: list[Label]) -> "Rule[ConfigT]":
         """Fit rule configuration from labeled samples, scikit-style.
 

--- a/src/slop_guard/rules/paragraph_level/blockquote_density_rule.py
+++ b/src/slop_guard/rules/paragraph_level/blockquote_density_rule.py
@@ -43,6 +43,20 @@ class BlockquoteDensityRule(Rule[BlockquoteDensityRuleConfig]):
     count_key = "blockquote_density"
     level = RuleLevel.PARAGRAPH
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger blockquote-density matches."""
+        return [
+            "> Claim one\n> Claim two\n> Claim three\nRegular line.",
+            "Lead.\n> Thesis one\n> Thesis two\n> Thesis three",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid blockquote-density matches."""
+        return [
+            "> One quote line\n> Second quote line\nThen regular prose.",
+            "Normal prose paragraph with no blockquote overuse.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Compute blockquote density and apply capped penalty scaling."""
         in_code_block = False

--- a/src/slop_guard/rules/paragraph_level/bold_term_bullet_run_rule.py
+++ b/src/slop_guard/rules/paragraph_level/bold_term_bullet_run_rule.py
@@ -40,6 +40,20 @@ class BoldTermBulletRunRule(Rule[BoldTermBulletRunRuleConfig]):
     count_key = "bold_bullet_list"
     level = RuleLevel.PARAGRAPH
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger bold-term bullet run matches."""
+        return [
+            "- **Reliability** improved\n- **Scalability** improved\n- **Security** improved",
+            "1) **Alpha** done\n2) **Beta** done\n3) **Gamma** done",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid bold-term bullet run matches."""
+        return [
+            "- **Reliability** improved\n- **Scalability** improved\nSummary line.",
+            "- plain bullet\n- plain bullet\n- plain bullet",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Track contiguous bold-term bullet runs and emit violations."""
         violations: list[Violation] = []

--- a/src/slop_guard/rules/paragraph_level/bullet_density_rule.py
+++ b/src/slop_guard/rules/paragraph_level/bullet_density_rule.py
@@ -40,6 +40,20 @@ class BulletDensityRule(Rule[BulletDensityRuleConfig]):
     count_key = "bullet_density"
     level = RuleLevel.PARAGRAPH
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger bullet-density matches."""
+        return [
+            "- first item\n- second item\nContext line.",
+            "1) alpha\n2) beta\n3) gamma\nSummary.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid bullet-density matches."""
+        return [
+            "Intro line.\n- one bullet\nDetails continue here.\nClosing line.",
+            "Paragraph-only explanatory text with no list dominance.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Compute non-empty line bullet ratio and flag if too high."""
         total_non_empty = len(document.non_empty_lines)

--- a/src/slop_guard/rules/paragraph_level/horizontal_rule_overuse_rule.py
+++ b/src/slop_guard/rules/paragraph_level/horizontal_rule_overuse_rule.py
@@ -44,6 +44,20 @@ class HorizontalRuleOveruseRule(Rule[HorizontalRuleOveruseRuleConfig]):
     count_key = "horizontal_rules"
     level = RuleLevel.PARAGRAPH
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger horizontal-rule matches."""
+        return [
+            "---\n---\n---\n---\nSection text.",
+            "***\n***\n***\n***\nSummary.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid horizontal-rule matches."""
+        return [
+            "---\n---\n---\nSection text.",
+            "Section one.\nSection two.\nNo divider overuse.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply horizontal-rule count thresholding."""
         count = len(_HORIZONTAL_RULE_RE.findall(document.text))

--- a/src/slop_guard/rules/paragraph_level/structural_pattern_rule.py
+++ b/src/slop_guard/rules/paragraph_level/structural_pattern_rule.py
@@ -51,6 +51,20 @@ class StructuralPatternRule(Rule[StructuralPatternRuleConfig]):
     count_key = "structural"
     level = RuleLevel.PARAGRAPH
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger structural-pattern matches."""
+        return [
+            "Fast, reliable, and maintainable.",
+            "**Problem:** latency\n**Cause:** retries\n**Fix:** batching",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid structural-pattern matches."""
+        return [
+            "The section opens with one heading followed by normal paragraphs.",
+            "The system is reliable and maintainable at this workload.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply structural pattern checks across lines and full text."""
         violations: list[Violation] = []

--- a/src/slop_guard/rules/passage_level/colon_density_rule.py
+++ b/src/slop_guard/rules/passage_level/colon_density_rule.py
@@ -47,6 +47,20 @@ class ColonDensityRule(Rule[ColonDensityRuleConfig]):
     count_key = "colon_density"
     level = RuleLevel.PASSAGE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger colon-density matches."""
+        return [
+            "Plan: retry quickly. Next: log errors. Finally: alert on failure.",
+            "Key idea: reduce retries. Why: fewer cascades.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid colon-density matches."""
+        return [
+            "The design avoids excessive elaboration punctuation in prose.",
+            "See https://example.com:443 for endpoint metadata.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Compute elaboration-colon density for prose lines."""
         stripped_text = document.text_without_code_blocks

--- a/src/slop_guard/rules/passage_level/em_dash_density_rule.py
+++ b/src/slop_guard/rules/passage_level/em_dash_density_rule.py
@@ -45,6 +45,20 @@ class EmDashDensityRule(Rule[EmDashDensityRuleConfig]):
     count_key = "em_dash"
     level = RuleLevel.PASSAGE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger em-dash density matches."""
+        return [
+            "Alpha -- beta gamma delta epsilon zeta eta theta iota kappa.",
+            "This plan — while simple — now works.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid em-dash density matches."""
+        return [
+            "Punctuation primarily uses commas and periods with clear flow.",
+            "Occasional emphasis appears once in longer sections without dash overuse.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Compute em-dash-per-basis ratio and emit one density violation."""
         if document.word_count <= 0:

--- a/src/slop_guard/rules/passage_level/phrase_reuse_rule.py
+++ b/src/slop_guard/rules/passage_level/phrase_reuse_rule.py
@@ -48,6 +48,26 @@ class PhraseReuseRule(Rule[PhraseReuseRuleConfig]):
     count_key = "phrase_reuse"
     level = RuleLevel.PASSAGE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger phrase-reuse matches."""
+        return [
+            (
+                "red blue green yellow red blue green yellow "
+                "red blue green yellow"
+            ),
+            (
+                "we deploy with canary rollout we deploy with canary rollout "
+                "we deploy with canary rollout"
+            ),
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid phrase-reuse matches."""
+        return [
+            "Each paragraph expresses a related idea with different wording.",
+            "The rollout, validation, and recovery sections use distinct phrasing.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Run repeated n-gram detection and emit capped findings."""
         tokens = document.ngram_tokens_lower

--- a/src/slop_guard/rules/passage_level/rhythm_rule.py
+++ b/src/slop_guard/rules/passage_level/rhythm_rule.py
@@ -43,6 +43,38 @@ class RhythmRule(Rule[RhythmRuleConfig]):
     count_key = "rhythm"
     level = RuleLevel.PASSAGE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger rhythm matches."""
+        return [
+            (
+                "Alpha beta gamma delta. "
+                "Alpha beta gamma delta. "
+                "Alpha beta gamma delta. "
+                "Alpha beta gamma delta. "
+                "Alpha beta gamma delta."
+            ),
+            (
+                "One two three four. "
+                "Five six seven eight. "
+                "Nine ten eleven twelve. "
+                "Thirteen fourteen fifteen sixteen. "
+                "Seventeen eighteen nineteen twenty."
+            ),
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid rhythm matches."""
+        return [
+            "Short note. Still short. Not enough sentences. Stop.",
+            (
+                "Tiny line. "
+                "This sentence has many extra words for strong variation now. "
+                "Brief again. "
+                "Another long sentence appears with additional explanatory detail. "
+                "Done."
+            ),
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Compute sentence-length CV and emit a rhythm violation if low."""
         sentence_count = len(document.sentence_word_counts)

--- a/src/slop_guard/rules/sentence_level/ai_disclosure_rule.py
+++ b/src/slop_guard/rules/sentence_level/ai_disclosure_rule.py
@@ -65,6 +65,20 @@ class AIDisclosureRule(Rule[AIDisclosureRuleConfig]):
     count_key = "ai_disclosure"
     level = RuleLevel.SENTENCE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger AI-disclosure matches."""
+        return [
+            "As an AI language model, I cannot browse the web.",
+            "I'm just an AI, so I do not have personal experience.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid AI-disclosure matches."""
+        return [
+            "The report uses only the provided dataset.",
+            "I do not have evidence for that claim.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply disclosure regex checks to the text."""
         violations: list[Violation] = []

--- a/src/slop_guard/rules/sentence_level/contrast_pair_rule.py
+++ b/src/slop_guard/rules/sentence_level/contrast_pair_rule.py
@@ -46,6 +46,20 @@ class ContrastPairRule(Rule[ContrastPairRuleConfig]):
     count_key = "contrast_pairs"
     level = RuleLevel.SENTENCE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger contrast-pair matches."""
+        return [
+            "This is focus, not frenzy.",
+            "It is clarity, not complexity.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid contrast-pair matches."""
+        return [
+            "This approach prioritizes focus over speed.",
+            "The design reduces complexity while improving clarity.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply contrast detection and aggregate advice."""
         matches = list(_CONTRAST_PAIR_RE.finditer(document.text))

--- a/src/slop_guard/rules/sentence_level/pithy_fragment_rule.py
+++ b/src/slop_guard/rules/sentence_level/pithy_fragment_rule.py
@@ -45,6 +45,20 @@ class PithyFragmentRule(Rule[PithyFragmentRuleConfig]):
     count_key = "pithy_fragment"
     level = RuleLevel.SENTENCE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger pithy-fragment matches."""
+        return [
+            "Simple, but powerful.",
+            "Fast, yet reliable.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid pithy-fragment matches."""
+        return [
+            "The service is simple to run but expensive at peak load.",
+            "It is fast and reliable in this benchmark.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Scan sentence list for pithy pivot signatures."""
         violations: list[Violation] = []

--- a/src/slop_guard/rules/sentence_level/placeholder_rule.py
+++ b/src/slop_guard/rules/sentence_level/placeholder_rule.py
@@ -48,6 +48,20 @@ class PlaceholderRule(Rule[PlaceholderRuleConfig]):
     count_key = "placeholder"
     level = RuleLevel.SENTENCE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger placeholder matches."""
+        return [
+            "[insert source citation] before publishing.",
+            "Contact: [your email here]",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid placeholder matches."""
+        return [
+            "Contact: security@example.com",
+            "The appendix lists all citations.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply placeholder regex checks to the text."""
         violations: list[Violation] = []

--- a/src/slop_guard/rules/sentence_level/setup_resolution_rule.py
+++ b/src/slop_guard/rules/sentence_level/setup_resolution_rule.py
@@ -63,6 +63,20 @@ class SetupResolutionRule(Rule[SetupResolutionRuleConfig]):
     count_key = "setup_resolution"
     level = RuleLevel.SENTENCE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger setup-resolution matches."""
+        return [
+            "This is not about tooling. It is about discipline.",
+            "It's not random; it's deliberate.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid setup-resolution matches."""
+        return [
+            "The problem is tooling and team discipline.",
+            "This approach emphasizes discipline over tooling.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply both setup-resolution regex forms."""
         if (

--- a/src/slop_guard/rules/sentence_level/slop_phrase_rule.py
+++ b/src/slop_guard/rules/sentence_level/slop_phrase_rule.py
@@ -112,6 +112,20 @@ class SlopPhraseRule(Rule[SlopPhraseRuleConfig]):
     count_key = "slop_phrases"
     level = RuleLevel.SENTENCE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger slop-phrase matches."""
+        return [
+            "It's worth noting that reliability matters here.",
+            "This change is not just faster, but also easier to maintain.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid slop-phrase matches."""
+        return [
+            "Reliability matters because retries hide partial failures.",
+            "The next section covers deployment constraints.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply phrase and transition pattern checks."""
         violations: list[Violation] = []

--- a/src/slop_guard/rules/sentence_level/tone_marker_rule.py
+++ b/src/slop_guard/rules/sentence_level/tone_marker_rule.py
@@ -77,6 +77,20 @@ class ToneMarkerRule(Rule[ToneMarkerRuleConfig]):
     count_key = "tone"
     level = RuleLevel.SENTENCE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger tone-marker matches."""
+        return [
+            "Would you like me to provide a shorter version?",
+            "Certainly, this approach works in most environments.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid tone-marker matches."""
+        return [
+            "This approach works in most environments.",
+            "The failure occurred after the second retry.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply tone marker checks to full text."""
         violations: list[Violation] = []

--- a/src/slop_guard/rules/sentence_level/weasel_phrase_rule.py
+++ b/src/slop_guard/rules/sentence_level/weasel_phrase_rule.py
@@ -58,6 +58,20 @@ class WeaselPhraseRule(Rule[WeaselPhraseRuleConfig]):
     count_key = "weasel"
     level = RuleLevel.SENTENCE
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger weasel phrase matches."""
+        return [
+            "Many believe this framework is the future.",
+            "Studies show the feature improves trust.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid weasel phrase matches."""
+        return [
+            "A 2024 ACM paper reports a 12 percent error reduction.",
+            "We expect lower error rates based on last quarter's logs.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply weasel phrase regex checks."""
         violations: list[Violation] = []

--- a/src/slop_guard/rules/word_level/slop_word_rule.py
+++ b/src/slop_guard/rules/word_level/slop_word_rule.py
@@ -143,6 +143,20 @@ class SlopWordRule(Rule[SlopWordRuleConfig]):
     count_key = "slop_words"
     level = RuleLevel.WORD
 
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger slop-word matches."""
+        return [
+            "This is a crucial and groundbreaking update.",
+            "We can leverage a robust paradigm for growth.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid slop-word matches."""
+        return [
+            "This patch removes an O(n^2) loop in parsing.",
+            "P95 latency dropped from 180 ms to 95 ms after batching writes.",
+        ]
+
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply the slop-word detector to the full text."""
         violations: list[Violation] = []


### PR DESCRIPTION
## Description
- add example_violations and example_non_violations abstract methods to the base Rule contract
- implement both example fixture methods across every rule in the default registry
- add a parameterized framework test that iterates all registered default rules and asserts each rule's examples behave as expected

## Why?
- keeps rule behavior examples colocated with rule definitions
- makes the framework test modular by deriving coverage directly from the rule registry
- prevents drift between documented examples and real rule behavior

## Usage / Demonstration
- each rule now defines two example fixture methods
- example_violations returns text snippets that should trigger the rule
- example_non_violations returns text snippets that should not trigger the rule
- tests/test_rule_framework.py now runs a parameterized pass over build_default_rules(HYPERPARAMETERS) and validates both fixture lists for every rule

## Test Plan
- uv run --with pytest pytest tests/test_rule_framework.py -q
- uv run --with pytest pytest -q