### PR TITLE
feat: JSONL rule pipelines + configurable sg/slop-guard configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Add from the command line:
 
 ```bash
 claude mcp add slop-guard -- uvx slop-guard
+# Optional custom rule config:
+claude mcp add slop-guard -- uvx slop-guard -c /path/to/config.jsonl
 ```
 
 Add to your `.mcp.json`:
@@ -27,12 +29,27 @@ Add to your `.mcp.json`:
 }
 ```
 
+With a custom rule config:
+
+```json
+{
+  "mcpServers": {
+    "slop-guard": {
+      "command": "uvx",
+      "args": ["slop-guard", "-c", "/path/to/config.jsonl"]
+    }
+  }
+}
+```
+
 ### Codex
 
 Add from the command line:
 
 ```bash
 codex mcp add slop-guard -- uvx slop-guard
+# Optional custom rule config:
+codex mcp add slop-guard -- uvx slop-guard -c /path/to/config.jsonl
 ```
 
 Add to your `~/.codex/config.toml`:
@@ -41,6 +58,14 @@ Add to your `~/.codex/config.toml`:
 [mcp_servers.slop-guard]
 command = "uvx"
 args = ["slop-guard"]
+```
+
+With a custom rule config:
+
+```toml
+[mcp_servers.slop-guard]
+command = "uvx"
+args = ["slop-guard", "-c", "/path/to/config.jsonl"]
 ```
 
 If you want a fixed release, pin it in `args`, for example: `["slop-guard==0.2.0"]`.
@@ -88,7 +113,8 @@ sg path/**/*.md
 | `-v`, `--verbose` | Show individual violations and advice |
 | `-q`, `--quiet` | Only print sources that fail the threshold |
 | `-t SCORE`, `--threshold SCORE` | Minimum passing score (0-100). Exit 1 if any file scores below this |
-| `-c`, `--concise` | Print only numeric score output |
+| `-c JSONL`, `--config JSONL` | Path to JSONL rule configuration. Defaults to packaged settings |
+| `-s`, `--score-only` | Print only numeric score output |
 | `--counts` | Show per-rule hit counts in the summary line |
 
 ### Examples
@@ -98,8 +124,11 @@ sg path/**/*.md
 sg draft.md
 # => draft.md: 72/100 [light] (1843 words) *
 
-# Concise output (score only)
-sg -c draft.md
+# Score-only output
+sg -s draft.md
+
+# Use a custom rule config
+sg -c /path/to/config.jsonl draft.md
 
 # Verbose output with violations and advice
 sg -v draft.md
@@ -130,6 +159,8 @@ Run without installing (recommended for MCP setups):
 
 ```bash
 uvx slop-guard
+# MCP server with custom rule config
+uvx slop-guard -c /path/to/config.jsonl
 ```
 
 Install persistently (gives you both `slop-guard` MCP server and `sg` CLI):
@@ -155,7 +186,8 @@ uv tool upgrade slop-guard
 From a local checkout:
 
 ```bash
-uv run slop-guard   # MCP server
+uv run slop-guard               # MCP server
+uv run slop-guard -c config.jsonl
 uv run sg            # CLI linter
 ```
 

--- a/benchmark/compute-time.py
+++ b/benchmark/compute-time.py
@@ -25,9 +25,9 @@ SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-from slop_guard.analysis import AnalysisDocument, HYPERPARAMETERS  # noqa: E402
+from slop_guard.analysis import AnalysisDocument  # noqa: E402
 from slop_guard.rules.base import Rule, RuleConfig  # noqa: E402
-from slop_guard.rules.registry import build_default_rules  # noqa: E402
+from slop_guard.rules import build_default_rules  # noqa: E402
 
 RuleList: TypeAlias = list[Rule[RuleConfig]]
 BenchmarkRecord: TypeAlias = dict[str, str | int | float]
@@ -308,7 +308,7 @@ def parse_args() -> argparse.Namespace:
     """Parse benchmark CLI arguments."""
     parser = argparse.ArgumentParser(
         description=(
-            "Measure forward-pass compute time for every default registry rule "
+            "Measure forward-pass compute time for every default configured rule "
             "across synthetic text lengths."
         )
     )
@@ -506,7 +506,7 @@ def main() -> None:
         length_mode=args.length_mode,
         num_lengths=args.num_lengths,
     )
-    rules = build_default_rules(HYPERPARAMETERS)
+    rules = build_default_rules()
     word_stream = build_word_stream(seed=args.seed, max_words=args.max_words)
     output_path = Path(args.output)
 

--- a/src/slop_guard/rules/__init__.py
+++ b/src/slop_guard/rules/__init__.py
@@ -1,10 +1,11 @@
 """Rule framework exports."""
 
 from .base import Rule, RuleConfig, RuleLevel
-from .pipeline import run_rule_pipeline
-from .registry import RuleList, build_default_rules
+from .pipeline import Pipeline, build_default_rules, run_rule_pipeline
+from .registry import RuleList
 
 __all__ = [
+    "Pipeline",
     "Rule",
     "RuleConfig",
     "RuleLevel",

--- a/src/slop_guard/rules/assets/default.jsonl
+++ b/src/slop_guard/rules/assets/default.jsonl
@@ -1,0 +1,18 @@
+{"config": {"context_window_chars": 60, "penalty": -2}, "rule_type": "slop_guard.rules.word_level.slop_word_rule.SlopWordRule"}
+{"config": {"context_window_chars": 60, "penalty": -3}, "rule_type": "slop_guard.rules.sentence_level.slop_phrase_rule.SlopPhraseRule"}
+{"config": {"bold_header_min": 3, "bold_header_penalty": -5, "bullet_run_min": 6, "bullet_run_penalty": -3, "context_window_chars": 60, "triadic_advice_min": 3, "triadic_penalty": -1, "triadic_record_cap": 5}, "rule_type": "slop_guard.rules.paragraph_level.structural_pattern_rule.StructuralPatternRule"}
+{"config": {"context_window_chars": 60, "sentence_opener_penalty": -2, "tone_penalty": -3}, "rule_type": "slop_guard.rules.sentence_level.tone_marker_rule.ToneMarkerRule"}
+{"config": {"context_window_chars": 60, "penalty": -2}, "rule_type": "slop_guard.rules.sentence_level.weasel_phrase_rule.WeaselPhraseRule"}
+{"config": {"context_window_chars": 60, "penalty": -10}, "rule_type": "slop_guard.rules.sentence_level.ai_disclosure_rule.AIDisclosureRule"}
+{"config": {"context_window_chars": 60, "penalty": -5}, "rule_type": "slop_guard.rules.sentence_level.placeholder_rule.PlaceholderRule"}
+{"config": {"cv_threshold": 0.3, "min_sentences": 5, "penalty": -5}, "rule_type": "slop_guard.rules.passage_level.rhythm_rule.RhythmRule"}
+{"config": {"density_threshold": 1.0, "penalty": -3, "words_basis": 150.0}, "rule_type": "slop_guard.rules.passage_level.em_dash_density_rule.EmDashDensityRule"}
+{"config": {"advice_min": 2, "context_window_chars": 60, "penalty": -1, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence_level.contrast_pair_rule.ContrastPairRule"}
+{"config": {"context_window_chars": 60, "penalty": -3, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence_level.setup_resolution_rule.SetupResolutionRule"}
+{"config": {"density_threshold": 1.5, "penalty": -3, "words_basis": 150.0}, "rule_type": "slop_guard.rules.passage_level.colon_density_rule.ColonDensityRule"}
+{"config": {"max_sentence_words": 6, "penalty": -2, "record_cap": 3}, "rule_type": "slop_guard.rules.sentence_level.pithy_fragment_rule.PithyFragmentRule"}
+{"config": {"penalty": -8, "ratio_threshold": 0.4}, "rule_type": "slop_guard.rules.paragraph_level.bullet_density_rule.BulletDensityRule"}
+{"config": {"cap": 4, "free_lines": 2, "min_lines": 3, "penalty_step": -3}, "rule_type": "slop_guard.rules.paragraph_level.blockquote_density_rule.BlockquoteDensityRule"}
+{"config": {"min_run_length": 3, "penalty": -5}, "rule_type": "slop_guard.rules.paragraph_level.bold_term_bullet_run_rule.BoldTermBulletRunRule"}
+{"config": {"min_count": 4, "penalty": -3}, "rule_type": "slop_guard.rules.paragraph_level.horizontal_rule_overuse_rule.HorizontalRuleOveruseRule"}
+{"config": {"penalty": -1, "record_cap": 5, "repeated_ngram_max_n": 8, "repeated_ngram_min_count": 3, "repeated_ngram_min_n": 4}, "rule_type": "slop_guard.rules.passage_level.phrase_reuse_rule.PhraseReuseRule"}

--- a/src/slop_guard/rules/pipeline.py
+++ b/src/slop_guard/rules/pipeline.py
@@ -1,13 +1,82 @@
-"""Rule execution pipeline for analysis forward passes."""
+"""Rule pipeline orchestration and JSONL serialization helpers."""
 
 
+import json
+from collections.abc import Iterable, Mapping
+from importlib.resources import files
+from pathlib import Path
 from typing import TypeAlias
 
 from slop_guard.analysis import AnalysisDocument, AnalysisState
 
-from .base import Rule, RuleConfig
+from .base import Label, Rule, RuleConfig
+from .registry import resolve_rule_type, rule_type_name
 
 RuleList: TypeAlias = list[Rule[RuleConfig]]
+
+_RULE_TYPE_FIELD = "rule_type"
+_CONFIG_FIELD = "config"
+
+
+class Pipeline:
+    """Ordered rule pipeline with JSONL load/save and fit orchestration."""
+
+    def __init__(self, rules: list[Rule[RuleConfig]]) -> None:
+        """Initialize a pipeline from an ordered list of instantiated rules."""
+        self.rules = list(rules)
+
+    @classmethod
+    def from_jsonl(cls, path: str | Path | None = None) -> "Pipeline":
+        """Build a pipeline from a JSONL rule-settings file.
+
+        Args:
+            path: JSONL path. If omitted, loads packaged defaults.
+        """
+        raw_lines = _read_jsonl_lines(path)
+        rules = _parse_rules_from_jsonl(raw_lines)
+        if not rules:
+            source = "<package default>" if path is None else str(path)
+            raise ValueError(f"JSONL rule configuration is empty: {source}")
+        return cls(rules)
+
+    def to_jsonl(self, path: str | Path) -> None:
+        """Write this pipeline's rule settings to a JSONL file."""
+        output_path = Path(path)
+        with output_path.open("w", encoding="utf-8") as handle:
+            for rule in self.rules:
+                payload = {
+                    _RULE_TYPE_FIELD: rule_type_name(type(rule)),
+                    _CONFIG_FIELD: rule.to_dict(),
+                }
+                handle.write(json.dumps(payload, sort_keys=True))
+                handle.write("\n")
+
+    def forward(self, document: AnalysisDocument) -> AnalysisState:
+        """Apply all rules in order and merge their outputs."""
+        state = AnalysisState.initial()
+        for rule in self.rules:
+            state = state.merge(rule.forward(document))
+        return state
+
+    def fit(
+        self, samples: list[str], labels: list[Label] | None = None
+    ) -> "Pipeline":
+        """Fit each rule against shared samples/labels and return self.
+
+        Args:
+            samples: Text samples used to fit each rule.
+            labels: Optional integer labels. If omitted, all samples are
+                treated as positives.
+        """
+        fit_labels = labels if labels is not None else [1] * len(samples)
+        for rule in self.rules:
+            rule.fit(samples, fit_labels)
+        return self
+
+
+def build_default_rules() -> RuleList:
+    """Return default configured rules from packaged JSONL settings."""
+    return list(Pipeline.from_jsonl().rules)
 
 
 def run_rule_pipeline(
@@ -15,7 +84,48 @@ def run_rule_pipeline(
     rules: list[Rule[RuleConfig]],
 ) -> AnalysisState:
     """Apply an ordered list of instantiated rules and merge outputs."""
-    state = AnalysisState.initial()
-    for rule in rules:
-        state = state.merge(rule.forward(document))
-    return state
+    return Pipeline(rules).forward(document)
+
+
+def _read_jsonl_lines(path: str | Path | None) -> list[str]:
+    """Read raw JSONL lines from a path or packaged defaults."""
+    if path is None:
+        raw_text = (
+            files("slop_guard.rules")
+            .joinpath("assets/default.jsonl")
+            .read_text(encoding="utf-8")
+        )
+        return raw_text.splitlines()
+    return Path(path).read_text(encoding="utf-8").splitlines()
+
+
+def _parse_rules_from_jsonl(lines: Iterable[str]) -> RuleList:
+    """Parse and instantiate rules from JSONL lines."""
+    rules: RuleList = []
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON on line {line_number}: {exc.msg}") from exc
+
+        if not isinstance(payload, dict):
+            raise TypeError(f"Line {line_number} must be a JSON object")
+
+        rule_type_raw = payload.get(_RULE_TYPE_FIELD)
+        if not isinstance(rule_type_raw, str):
+            raise TypeError(
+                f"Line {line_number} must contain string '{_RULE_TYPE_FIELD}'"
+            )
+
+        config_raw = payload.get(_CONFIG_FIELD)
+        if not isinstance(config_raw, Mapping):
+            raise TypeError(f"Line {line_number} must contain object '{_CONFIG_FIELD}'")
+
+        rule_type = resolve_rule_type(rule_type_raw)
+        rules.append(rule_type.from_dict(config_raw))
+
+    return rules

--- a/src/slop_guard/rules/registry.py
+++ b/src/slop_guard/rules/registry.py
@@ -1,184 +1,75 @@
-"""Rule registry and default pipeline construction."""
+"""Rule registry and class resolution helpers."""
 
 
 from typing import TypeAlias
 
-from slop_guard.analysis import Hyperparameters
-
 from .base import Rule, RuleConfig
 from .paragraph_level import (
     BlockquoteDensityRule,
-    BlockquoteDensityRuleConfig,
     BoldTermBulletRunRule,
-    BoldTermBulletRunRuleConfig,
     BulletDensityRule,
-    BulletDensityRuleConfig,
     HorizontalRuleOveruseRule,
-    HorizontalRuleOveruseRuleConfig,
     StructuralPatternRule,
-    StructuralPatternRuleConfig,
 )
 from .passage_level import (
     ColonDensityRule,
-    ColonDensityRuleConfig,
     EmDashDensityRule,
-    EmDashDensityRuleConfig,
     PhraseReuseRule,
-    PhraseReuseRuleConfig,
     RhythmRule,
-    RhythmRuleConfig,
 )
 from .sentence_level import (
     AIDisclosureRule,
-    AIDisclosureRuleConfig,
     ContrastPairRule,
-    ContrastPairRuleConfig,
     PithyFragmentRule,
-    PithyFragmentRuleConfig,
     PlaceholderRule,
-    PlaceholderRuleConfig,
     SetupResolutionRule,
-    SetupResolutionRuleConfig,
     SlopPhraseRule,
-    SlopPhraseRuleConfig,
     ToneMarkerRule,
-    ToneMarkerRuleConfig,
     WeaselPhraseRule,
-    WeaselPhraseRuleConfig,
 )
-from .word_level import SlopWordRule, SlopWordRuleConfig
+from .word_level import SlopWordRule
 
+RuleType: TypeAlias = type[Rule[RuleConfig]]
 RuleList: TypeAlias = list[Rule[RuleConfig]]
 
+DEFAULT_RULE_TYPES: tuple[RuleType, ...] = (
+    SlopWordRule,
+    SlopPhraseRule,
+    StructuralPatternRule,
+    ToneMarkerRule,
+    WeaselPhraseRule,
+    AIDisclosureRule,
+    PlaceholderRule,
+    RhythmRule,
+    EmDashDensityRule,
+    ContrastPairRule,
+    SetupResolutionRule,
+    ColonDensityRule,
+    PithyFragmentRule,
+    BulletDensityRule,
+    BlockquoteDensityRule,
+    BoldTermBulletRunRule,
+    HorizontalRuleOveruseRule,
+    PhraseReuseRule,
+)
 
-def build_default_rules(hp: Hyperparameters) -> RuleList:
-    """Instantiate the default ordered analyzer rule pipeline."""
-    return [
-        SlopWordRule(
-            SlopWordRuleConfig(
-                penalty=hp.slop_word_penalty,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        SlopPhraseRule(
-            SlopPhraseRuleConfig(
-                penalty=hp.slop_phrase_penalty,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        StructuralPatternRule(
-            StructuralPatternRuleConfig(
-                bold_header_min=hp.structural_bold_header_min,
-                bold_header_penalty=hp.structural_bold_header_penalty,
-                bullet_run_min=hp.structural_bullet_run_min,
-                bullet_run_penalty=hp.structural_bullet_run_penalty,
-                triadic_record_cap=hp.triadic_record_cap,
-                triadic_penalty=hp.triadic_penalty,
-                triadic_advice_min=hp.triadic_advice_min,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        ToneMarkerRule(
-            ToneMarkerRuleConfig(
-                tone_penalty=hp.tone_penalty,
-                sentence_opener_penalty=hp.sentence_opener_penalty,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        WeaselPhraseRule(
-            WeaselPhraseRuleConfig(
-                penalty=hp.weasel_penalty,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        AIDisclosureRule(
-            AIDisclosureRuleConfig(
-                penalty=hp.ai_disclosure_penalty,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        PlaceholderRule(
-            PlaceholderRuleConfig(
-                penalty=hp.placeholder_penalty,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        RhythmRule(
-            RhythmRuleConfig(
-                min_sentences=hp.rhythm_min_sentences,
-                cv_threshold=hp.rhythm_cv_threshold,
-                penalty=hp.rhythm_penalty,
-            )
-        ),
-        EmDashDensityRule(
-            EmDashDensityRuleConfig(
-                words_basis=hp.em_dash_words_basis,
-                density_threshold=hp.em_dash_density_threshold,
-                penalty=hp.em_dash_penalty,
-            )
-        ),
-        ContrastPairRule(
-            ContrastPairRuleConfig(
-                penalty=hp.contrast_penalty,
-                record_cap=hp.contrast_record_cap,
-                advice_min=hp.contrast_advice_min,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        SetupResolutionRule(
-            SetupResolutionRuleConfig(
-                penalty=hp.setup_resolution_penalty,
-                record_cap=hp.setup_resolution_record_cap,
-                context_window_chars=hp.context_window_chars,
-            )
-        ),
-        ColonDensityRule(
-            ColonDensityRuleConfig(
-                words_basis=hp.colon_words_basis,
-                density_threshold=hp.colon_density_threshold,
-                penalty=hp.colon_density_penalty,
-            )
-        ),
-        PithyFragmentRule(
-            PithyFragmentRuleConfig(
-                penalty=hp.pithy_penalty,
-                max_sentence_words=hp.pithy_max_sentence_words,
-                record_cap=hp.pithy_record_cap,
-            )
-        ),
-        BulletDensityRule(
-            BulletDensityRuleConfig(
-                ratio_threshold=hp.bullet_density_threshold,
-                penalty=hp.bullet_density_penalty,
-            )
-        ),
-        BlockquoteDensityRule(
-            BlockquoteDensityRuleConfig(
-                min_lines=hp.blockquote_min_lines,
-                free_lines=hp.blockquote_free_lines,
-                cap=hp.blockquote_cap,
-                penalty_step=hp.blockquote_penalty_step,
-            )
-        ),
-        BoldTermBulletRunRule(
-            BoldTermBulletRunRuleConfig(
-                min_run_length=hp.bold_bullet_run_min,
-                penalty=hp.bold_bullet_run_penalty,
-            )
-        ),
-        HorizontalRuleOveruseRule(
-            HorizontalRuleOveruseRuleConfig(
-                min_count=hp.horizontal_rule_min,
-                penalty=hp.horizontal_rule_penalty,
-            )
-        ),
-        PhraseReuseRule(
-            PhraseReuseRuleConfig(
-                penalty=hp.phrase_reuse_penalty,
-                record_cap=hp.phrase_reuse_record_cap,
-                repeated_ngram_min_n=hp.repeated_ngram_min_n,
-                repeated_ngram_max_n=hp.repeated_ngram_max_n,
-                repeated_ngram_min_count=hp.repeated_ngram_min_count,
-            )
-        ),
-    ]
+
+def rule_type_name(rule_type: RuleType) -> str:
+    """Return the canonical fully-qualified name for a rule class."""
+    return f"{rule_type.__module__}.{rule_type.__name__}"
+
+
+_RULE_TYPES_BY_KEY: dict[str, RuleType] = {}
+for _rule_type in DEFAULT_RULE_TYPES:
+    _RULE_TYPES_BY_KEY[rule_type_name(_rule_type)] = _rule_type
+    _RULE_TYPES_BY_KEY[_rule_type.__name__] = _rule_type
+del _rule_type
+
+
+def resolve_rule_type(rule_type: str) -> RuleType:
+    """Resolve a rule class from a full or short class name."""
+    resolved = _RULE_TYPES_BY_KEY.get(rule_type)
+    if resolved is None:
+        known = ", ".join(sorted(_RULE_TYPES_BY_KEY))
+        raise KeyError(f"Unknown rule_type '{rule_type}'. Known rule types: {known}")
+    return resolved

--- a/tests/test_pipeline_jsonl.py
+++ b/tests/test_pipeline_jsonl.py
@@ -1,0 +1,88 @@
+"""Tests for JSONL-backed rule pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from slop_guard.analysis import AnalysisDocument, RuleResult
+from slop_guard.rules import Pipeline, Rule, RuleConfig, run_rule_pipeline
+
+
+def test_pipeline_jsonl_round_trip_preserves_rules_and_configs(
+    tmp_path: Path,
+) -> None:
+    """Writing then reading a pipeline should preserve order and settings."""
+    pipeline = Pipeline.from_jsonl()
+    output_path = tmp_path / "round_trip.jsonl"
+    pipeline.to_jsonl(output_path)
+
+    rebuilt = Pipeline.from_jsonl(output_path)
+    assert [type(rule) for rule in rebuilt.rules] == [
+        type(rule) for rule in pipeline.rules
+    ]
+    assert [rule.to_dict() for rule in rebuilt.rules] == [
+        rule.to_dict() for rule in pipeline.rules
+    ]
+
+
+def test_pipeline_forward_matches_legacy_helper() -> None:
+    """Pipeline.forward should match the helper-style pipeline execution."""
+    document = AnalysisDocument.from_text(
+        "This is a crucial and groundbreaking paradigm for modern teams."
+    )
+    pipeline = Pipeline.from_jsonl()
+
+    assert pipeline.forward(document) == run_rule_pipeline(document, pipeline.rules)
+
+
+@dataclass
+class _RecordingConfig(RuleConfig):
+    """Minimal config used by the recording test rule."""
+
+    fit_count: int
+
+
+class _RecordingRule(Rule[_RecordingConfig]):
+    """Test helper rule that records fit inputs."""
+
+    name = "recording"
+    count_key = "recording"
+    fit_calls: list[tuple[list[str], list[int]]] = []
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Return an empty result for fit-focused testing."""
+        _ = document
+        return RuleResult()
+
+    def example_violations(self) -> list[str]:
+        """Return one example to satisfy the abstract interface."""
+        return ["violation example"]
+
+    def example_non_violations(self) -> list[str]:
+        """Return one non-example to satisfy the abstract interface."""
+        return ["non-violation example"]
+
+    def _fit(self, samples: list[str], labels: list[int]) -> _RecordingConfig:
+        """Record fit inputs and increment fit count."""
+        self.fit_calls.append((list(samples), list(labels)))
+        return _RecordingConfig(fit_count=self.config.fit_count + 1)
+
+
+def test_pipeline_fit_runs_all_rules_and_supports_default_labels() -> None:
+    """Pipeline.fit should fit each rule and default labels to all positives."""
+    _RecordingRule.fit_calls = []
+
+    first = _RecordingRule(_RecordingConfig(fit_count=0))
+    second = _RecordingRule(_RecordingConfig(fit_count=1))
+    pipeline = Pipeline([first, second])
+
+    fitted = pipeline.fit(["alpha", "beta"])
+
+    assert fitted is pipeline
+    assert _RecordingRule.fit_calls == [
+        (["alpha", "beta"], [1, 1]),
+        (["alpha", "beta"], [1, 1]),
+    ]
+    assert first.config.fit_count == 1
+    assert second.config.fit_count == 2

--- a/tests/test_rule_framework.py
+++ b/tests/test_rule_framework.py
@@ -4,13 +4,13 @@
 import pytest
 
 from slop_guard.analysis import AnalysisDocument, HYPERPARAMETERS
-from slop_guard.rules import Rule, RuleConfig, RuleLevel, build_default_rules
+from slop_guard.rules import Pipeline, Rule, RuleConfig, RuleLevel
 from slop_guard.rules.word_level import SlopWordRule, SlopWordRuleConfig
 
 
-def test_build_default_rules_covers_all_levels() -> None:
-    """Default rule registry should include each configured rule level."""
-    rules = build_default_rules(HYPERPARAMETERS)
+def test_default_pipeline_covers_all_levels() -> None:
+    """Default pipeline should include each configured rule level."""
+    rules = Pipeline.from_jsonl().rules
     levels = {rule.level for rule in rules}
     assert levels == {
         RuleLevel.WORD,
@@ -62,7 +62,7 @@ def test_rule_to_dict_from_dict_round_trip() -> None:
     assert rebuilt.config == rule.config
 
 
-_DEFAULT_RULES = build_default_rules(HYPERPARAMETERS)
+_DEFAULT_RULES = Pipeline.from_jsonl().rules
 _RULE_EXAMPLE_IDS = [
     f"{index:02d}-{rule.__class__.__name__}" for index, rule in enumerate(_DEFAULT_RULES)
 ]

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -1,0 +1,50 @@
+"""Tests for the ``slop-guard`` MCP server launcher CLI."""
+
+from __future__ import annotations
+
+from slop_guard import server
+
+
+def test_main_loads_default_pipeline_when_config_not_provided(
+    monkeypatch,
+) -> None:
+    """Server launch should load packaged pipeline defaults by default."""
+    loaded_paths: list[str | None] = []
+    sentinel_pipeline = object()
+    run_calls: list[bool] = []
+
+    def fake_from_jsonl(cls, path: str | None = None):  # noqa: ANN001
+        loaded_paths.append(path)
+        return sentinel_pipeline
+
+    monkeypatch.setattr(server.Pipeline, "from_jsonl", classmethod(fake_from_jsonl))
+    monkeypatch.setattr(server.mcp_server, "run", lambda: run_calls.append(True))
+
+    server.main([])
+
+    assert loaded_paths == [None]
+    assert run_calls == [True]
+    assert server.ACTIVE_PIPELINE is sentinel_pipeline
+
+
+def test_main_loads_custom_pipeline_when_config_is_provided(
+    monkeypatch,
+) -> None:
+    """Server launch should load a custom pipeline when ``-c`` is passed."""
+    loaded_paths: list[str | None] = []
+    sentinel_pipeline = object()
+    run_calls: list[bool] = []
+    config_path = "/tmp/custom-settings.jsonl"
+
+    def fake_from_jsonl(cls, path: str | None = None):  # noqa: ANN001
+        loaded_paths.append(path)
+        return sentinel_pipeline
+
+    monkeypatch.setattr(server.Pipeline, "from_jsonl", classmethod(fake_from_jsonl))
+    monkeypatch.setattr(server.mcp_server, "run", lambda: run_calls.append(True))
+
+    server.main(["-c", config_path])
+
+    assert loaded_paths == [config_path]
+    assert run_calls == [True]
+    assert server.ACTIVE_PIPELINE is sentinel_pipeline


### PR DESCRIPTION
## Description
- Added a first-class `Pipeline` abstraction in `src/slop_guard/rules/pipeline.py` with:
  - `Pipeline.from_jsonl(path: str | Path | None = None)`
  - `Pipeline.to_jsonl(path)`
  - `Pipeline.forward(document)`
  - `Pipeline.fit(samples, labels=None)`
- Added packaged default pipeline settings at `src/slop_guard/rules/assets/default.jsonl` and switched default rule construction to load from this asset.
- Refactored the registry to focus on rule metadata/class resolution only (`DEFAULT_RULE_TYPES`, canonical `rule_type` naming, and resolution by short or fully-qualified name), without pipeline/config construction dependency.
- Updated CLI flags for `sg`:
  - `-c/--config JSONL` now selects a JSONL rule config file (optional; defaults to packaged asset)
  - `-s/--score-only` now handles score-only output (old `-c/--concise` behavior)
- Added MCP launcher config support for `slop-guard`:
  - `-c/--config JSONL` to load a custom pipeline at startup.
- Updated benchmark harness import usage in `benchmark/compute-time.py` to the new rule-construction location.
- Updated README usage/docs for both CLI and MCP config paths.
- Added/updated tests covering JSONL round-trip, pipeline fitting/forward behavior, CLI config + score-only behavior, and MCP launcher config behavior.

## Why?
- Moves default rule settings from hardcoded wiring to a data asset that can be versioned, inspected, exported, and reloaded.
- Enables user-controlled analyzer behavior in both CLI and MCP without code changes.
- Keeps module boundaries clean: registry now describes built-in rules, pipeline handles config loading/serialization/execution.
- Preserves benchmark/scoring correspondence while improving configuration ergonomics.

## Usage / Demonstration
```bash
# Default packaged settings
sg README.md

# Score-only output (new flag)
sg -s README.md

# Custom settings for CLI
sg -c /path/to/config.jsonl README.md

# MCP server with custom settings
uvx slop-guard -c /path/to/config.jsonl
```

```python
from slop_guard.rules import Pipeline

pipeline = Pipeline.from_jsonl()  # packaged default asset
pipeline.fit(my_corpus)
pipeline.to_jsonl("/path/to/fitted.jsonl")
```

## Test Plan
- `uv run --with pytest pytest -q`
  - Result: `35 passed`
- `uv run benchmark/compute-time.py --min-words 10 --max-words 120 --length-mode linear --num-lengths 6 --repeats 1 --warmup-runs 0 --output /tmp/rule_compute_time.smoke.jsonl`
  - Result: benchmark smoke run completed successfully (`18 rules`, `6 lengths`, `108 rows`).
- Manual correspondence verification:
  - Confirmed default JSONL pipeline rule order/types/config values exactly match the previous hyperparameter-mapped defaults.
  - Confirmed `_analyze` outputs match exactly between legacy-mapped and JSONL-loaded pipelines across 300 generated benchmark-like samples.
