### PR TITLE
Release v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ command = "uvx"
 args = ["slop-guard", "-c", "/path/to/config.jsonl"]
 ```
 
-If you want a fixed release, pin it in `args`, for example: `["slop-guard==0.2.0"]`.
+If you want a fixed release, pin it in `args`, for example: `["slop-guard==0.3.0"]`.
 
 ## CLI
 
@@ -214,7 +214,7 @@ uv tool install slop-guard
 Pin versions for reproducibility:
 
 ```bash
-uvx slop-guard==0.2.0
+uvx slop-guard==0.3.0
 ```
 
 Upgrade an installed tool:

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -1,0 +1,67 @@
+# slop-guard v0.3.0
+
+v0.3.0 turns rule fitting into a first-class workflow and makes runtime configuration easier across both CLI and MCP usage. If you are upgrading from v0.2.0, the headline is simple: you can now train and ship your own rule settings with `sg-fit`.
+
+## Highlights
+
+- New `sg-fit` command to fit rule configs from real corpora and export JSONL settings.
+- Contrastive fitting support across all default rules with optional post-fit calibration.
+- Configurable rule pipelines for both `sg` and `slop-guard` MCP server via `-c/--config`.
+- Clearer CLI surface for scoring (`-s/--score-only`) and rule-config loading (`-c/--config`).
+
+## New in v0.3.0: `sg-fit`
+
+`sg-fit` is a dedicated fitting CLI for generating tuned rule settings from your own datasets.
+
+### Core workflow
+
+```bash
+# Legacy shorthand
+sg-fit TARGET_CORPUS OUTPUT
+
+# Multi-input mode
+sg-fit --output rules.fitted.jsonl data/*.jsonl docs/**/*.md
+```
+
+### What it supports
+
+- `.jsonl`, `.txt`, and `.md` inputs
+- Positive datasets (default label `1` when omitted)
+- Optional negative datasets via `--negative-dataset` (normalized to label `0`)
+- Initial config seeding via `--init`
+- Optional faster fitting via `--no-calibration`
+
+This makes it practical to fit settings for your team, export a JSONL config, and run that exact profile in both CLI and MCP environments.
+
+## Interface changes since v0.2.0
+
+These are the user-facing behavior changes to call out when upgrading:
+
+- `sg -c/--config` now means "load rule config JSONL".
+- Score-only output moved to `sg -s/--score-only`.
+- `slop-guard` MCP server also supports `-c/--config` for custom rule settings.
+- Removed legacy `--glob` argument behavior in `sg`; use shell expansion (`**/*.md`, etc.) instead.
+
+## Why this release matters
+
+v0.2.0 introduced the fit API foundation. v0.3.0 operationalizes it:
+
+- Every default rule now participates in empirical fitting.
+- Pipeline fit supports optional contrastive calibration.
+- Fitted configs are portable JSONL artifacts that can be versioned and reused.
+
+## Upgrade quickstart
+
+```bash
+# Pin this release
+uvx slop-guard==0.3.0
+
+# Fit a custom rule profile
+sg-fit data.jsonl rules.fitted.jsonl
+
+# Use fitted settings in CLI
+sg -c rules.fitted.jsonl draft.md
+
+# Use fitted settings in MCP server
+uvx slop-guard==0.3.0 -c /path/to/rules.fitted.jsonl
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slop-guard"
-version = "0.2.0"
+version = "0.3.0"
 description = "Rule-based prose linter for formulaic AI writing patterns."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -609,7 +609,7 @@ wheels = [
 
 [[package]]
 name = "slop-guard"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Description
- merge `codex/sg-fit-cli` into the release line so v0.3.0 includes the new `sg-fit` training CLI and contrastive fit improvements
- bump package version from `0.2.0` to `0.3.0`
- add `RELEASE_NOTES_v0.3.0.md` with a user-focused walkthrough of new features and upgrade-impacting interface changes
- update README version pin examples to `0.3.0`

## Why?
- v0.3.0 is the first release where fitting is a practical end-user workflow (`sg-fit` + portable JSONL configs)
- users upgrading from v0.2.0 need explicit guidance on CLI/MCP interface shifts (`-c` now config, `-s` score-only, shell glob usage)
- publish metadata and docs should align with the tagged version to keep PyPI and GitHub release messaging consistent

## Usage / Demonstration
- fit a custom rule profile:
  - `sg-fit data.jsonl rules.fitted.jsonl`
- run CLI with fitted settings:
  - `sg -c rules.fitted.jsonl draft.md`
- run MCP server with fitted settings:
  - `uvx slop-guard==0.3.0 -c /path/to/rules.fitted.jsonl`

## Test Plan
- `uv run --with pytest pytest`
- expected: all tests pass (66 passed)
