### PR TITLE
Add --version support to all CLI entry points

### DIFF
--- a/src/slop_guard/cli.py
+++ b/src/slop_guard/cli.py
@@ -40,6 +40,7 @@ from typing import Literal, TextIO, TypeAlias
 
 from .rules import Pipeline
 from .server import HYPERPARAMETERS, Hyperparameters, _analyze
+from .version import PACKAGE_VERSION
 
 # ---------------------------------------------------------------------------
 # Exit codes
@@ -147,6 +148,12 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="sg",
         description="Prose linter for AI slop patterns.",
         epilog="Pass file paths, '-' for stdin, or quoted inline text.",
+    )
+    p.add_argument(
+        "--version",
+        action="version",
+        version=PACKAGE_VERSION,
+        help="Show package version and exit.",
     )
     p.add_argument(
         "inputs",

--- a/src/slop_guard/fit_cli.py
+++ b/src/slop_guard/fit_cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TypeAlias
 
 from .rules import Pipeline
+from .version import PACKAGE_VERSION
 
 EXIT_OK = 0
 EXIT_ERROR = 2
@@ -26,6 +27,12 @@ def _build_parser() -> argparse.ArgumentParser:
             "Inputs can be .jsonl, .txt, or .md. JSONL rows must contain a string "
             "'text' field and may include an integer 'label' field."
         ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=PACKAGE_VERSION,
+        help="Show package version and exit.",
     )
     parser.add_argument(
         "inputs",

--- a/src/slop_guard/server.py
+++ b/src/slop_guard/server.py
@@ -19,6 +19,7 @@ from .analysis import (
     short_text_result,
 )
 from .rules import Pipeline
+from .version import PACKAGE_VERSION
 
 MCP_SERVER_NAME = "slop-guard"
 mcp_server = FastMCP(MCP_SERVER_NAME)
@@ -109,6 +110,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="slop-guard",
         description="Run the slop-guard MCP server on stdio.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=PACKAGE_VERSION,
+        help="Show package version and exit.",
     )
     parser.add_argument(
         "-c", "--config",

--- a/src/slop_guard/version.py
+++ b/src/slop_guard/version.py
@@ -1,0 +1,6 @@
+"""Version helpers for package and CLI metadata."""
+
+from importlib.metadata import version
+
+PACKAGE_NAME = "slop-guard"
+PACKAGE_VERSION: str = version(PACKAGE_NAME)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from slop_guard import cli
+from slop_guard.version import PACKAGE_VERSION
 
 
 def _fake_result(source: str, score: int = 75) -> dict[str, object]:
@@ -29,6 +30,19 @@ def test_requires_at_least_one_input(capsys: pytest.CaptureFixture[str]) -> None
 
     assert raised.value.code == cli.EXIT_ERROR
     assert "the following arguments are required: INPUT" in capsys.readouterr().err
+
+
+def test_version_flag_prints_package_version(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--version`` should print package version and exit cleanly."""
+    with pytest.raises(SystemExit) as raised:
+        cli.cli_main(["--version"])
+
+    assert raised.value.code == cli.EXIT_OK
+    captured = capsys.readouterr()
+    assert captured.out.strip() == PACKAGE_VERSION
+    assert captured.err == ""
 
 
 def test_accepts_inline_text_input(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_fit_cli.py
+++ b/tests/test_fit_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from slop_guard import fit_cli
+from slop_guard.version import PACKAGE_VERSION
 
 
 class _FakePipeline:
@@ -50,6 +51,19 @@ def _reset_fake_pipeline_state() -> None:
     _FakePipeline.last_labels = []
     _FakePipeline.last_calibrate_contrastive = None
     _FakePipeline.output_path = None
+
+
+def test_fit_main_version_flag_prints_package_version(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``sg-fit --version`` should print package version and exit cleanly."""
+    with pytest.raises(SystemExit) as raised:
+        fit_cli.fit_main(["--version"])
+
+    assert raised.value.code == fit_cli.EXIT_OK
+    captured = capsys.readouterr()
+    assert captured.out.strip() == PACKAGE_VERSION
+    assert captured.err == ""
 
 
 def test_fit_main_uses_default_positive_labels_and_writes_output(

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -2,7 +2,23 @@
 
 from __future__ import annotations
 
+import pytest
+
 from slop_guard import server
+from slop_guard.version import PACKAGE_VERSION
+
+
+def test_main_version_flag_prints_package_version(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``slop-guard --version`` should print package version and exit cleanly."""
+    with pytest.raises(SystemExit) as raised:
+        server.main(["--version"])
+
+    assert raised.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == PACKAGE_VERSION
+    assert captured.err == ""
 
 
 def test_main_loads_default_pipeline_when_config_not_provided(


### PR DESCRIPTION
## Description
- add a shared `slop_guard.version` module that resolves the installed package version
- wire `--version` into all argparse-powered CLIs: `sg`, `sg-fit`, and `slop-guard`
- add regression tests validating each CLI prints the package version and exits cleanly

## Why?
- all published command entry points should expose a consistent, standard way to report package version
- this simplifies debugging and support workflows by making version checks explicit and scriptable

## Usage / Demonstration
- `uv run sg --version` -> `0.3.0`
- `uv run sg-fit --version` -> `0.3.0`
- `uv run slop-guard --version` -> `0.3.0`

## Test Plan
- `uv run --with pytest pytest tests/test_cli.py tests/test_fit_cli.py tests/test_server_main.py`
- manually verify all three entry points print version and exit with status 0
