### PR TITLE
Add Data Designer prompt-sampled benchmark generator

### DIFF
--- a/benchmark/generate-pure-slop-data-designer.py
+++ b/benchmark/generate-pure-slop-data-designer.py
@@ -2,11 +2,11 @@
 # requires-python = ">=3.11"
 # dependencies = ["data-designer"]
 # ///
-"""Generate pure-slop benchmark text with Data Designer defaults.
+"""Generate broad writing samples with Data Designer defaults.
 
-This script intentionally generates low-quality, generic prose to benchmark slop
-detectors. It uses Data Designer's default model/provider configuration and the
-`nvidia-text` model alias by default.
+This script samples open-ended prompts and captures raw model output for
+benchmarking. It uses Data Designer's default model/provider configuration and
+the `nvidia-text` model alias by default.
 
 Example:
     uv run benchmark/generate-pure-slop-data-designer.py
@@ -35,9 +35,9 @@ JsonRecord: TypeAlias = dict[str, str]
 
 DEFAULT_MODEL_ALIAS = "nvidia-text"
 DEFAULT_NUM_RECORDS = 64
-DEFAULT_DATASET_NAME = "pure_slop_data_designer"
-DEFAULT_ARTIFACT_DIR = Path("benchmark/output/data_designer_pure_slop_artifacts")
-DEFAULT_OUTPUT_PATH = Path("benchmark/output/data_designer_pure_slop.jsonl")
+DEFAULT_DATASET_NAME = "data_designer_prompt_samples"
+DEFAULT_ARTIFACT_DIR = Path("benchmark/output/data_designer_prompt_samples_artifacts")
+DEFAULT_OUTPUT_PATH = Path("benchmark/output/data_designer_prompt_samples.jsonl")
 
 PROMPT_TEMPLATES: PromptTemplateValues = (
     "Write a blog about",
@@ -189,26 +189,16 @@ TOPICS_BY_DOMAIN: TopicValuesByDomain = {
     ),
 }
 
-SLOP_SYSTEM_PROMPT = """You write intentionally low-quality AI slop.
-Produce generic, repetitive, buzzword-heavy prose with vague claims, empty
-insights, and broad platitudes. Avoid concrete details, data, citations, and
-specific examples. Keep the tone confident and polished while saying very
-little of substance."""
+MODEL_PROMPT = """{{ prompt_template }} {{ topic }}.
 
-SLOP_USER_PROMPT = """{{ prompt_template }} {{ topic }}.
-
-Output requirements:
-- 3-5 paragraphs of pure AI slop prose.
-- Include cliches, transitions, and broad motivational framing.
-- Keep content generic and non-specific.
-- No bullets, no markdown, no headings."""
+Write 3-5 paragraphs for a general audience using a clear, confident tone."""
 
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line options."""
     parser = argparse.ArgumentParser(
         description=(
-            "Generate slop-heavy text samples using Data Designer defaults and "
+            "Generate text samples using Data Designer defaults and "
             "export them as JSONL."
         )
     )
@@ -216,7 +206,7 @@ def parse_args() -> argparse.Namespace:
         "--num-records",
         type=int,
         default=DEFAULT_NUM_RECORDS,
-        help=f"Number of slop examples to generate (default: {DEFAULT_NUM_RECORDS}).",
+        help=f"Number of examples to generate (default: {DEFAULT_NUM_RECORDS}).",
     )
     parser.add_argument(
         "--model-alias",
@@ -274,8 +264,7 @@ def build_config_builder(model_alias: str) -> DataDesignerConfigBuilder:
     config_builder.add_column(
         LLMTextColumnConfig(
             name="text",
-            prompt=SLOP_USER_PROMPT,
-            system_prompt=SLOP_SYSTEM_PROMPT,
+            prompt=MODEL_PROMPT,
             model_alias=model_alias,
         )
     )
@@ -317,7 +306,7 @@ def main() -> None:
     text_rows: list[JsonRecord] = [{"text": str(value)} for value in dataset["text"]]
     write_jsonl(path=output_path, rows=text_rows)
 
-    print(f"Generated {len(text_rows):,} pure slop examples.")
+    print(f"Generated {len(text_rows):,} examples.")
     print(f"JSONL output: {output_path.resolve()}")
     print(f"Artifacts: {results.artifact_storage.base_dataset_path.resolve()}")
 


### PR DESCRIPTION
## Description
- Add `benchmark/generate-pure-slop-data-designer.py` as a standalone `uv` script with `data-designer` dependency metadata.
- Configure Data Designer generation with sampler-driven prompt construction:
  - `prompt_template` from a category sampler.
  - `topic_domain` from a category sampler.
  - `topic` from a subcategory sampler keyed by `topic_domain`.
- Generate a single `text` column via `LLMTextColumnConfig` using Data Designer defaults and `nvidia-text` model alias.
- Expand prompt diversity 4x and topic diversity 4x:
  - `24` prompt templates.
  - `100` topical possibilities.
- Keep prompting neutral (no explicit "ask for slop") so output reflects the model's natural writing tendencies.
- Default output paths:
  - `benchmark/output/data_designer_prompt_samples.jsonl`
  - `benchmark/output/data_designer_prompt_samples_artifacts/`

## Why?
- Adds a reproducible benchmark data generator that captures broad real-world writing behavior from the default model setup.
- Keeps prompt/topic randomness inside Data Designer samplers rather than ad-hoc randomization.
- Improves coverage substantially by expanding template/topic spaces while keeping the generation pipeline simple.

## Usage / Demonstration
Run:
```bash
uv run benchmark/generate-pure-slop-data-designer.py
```

Example run used for PR sample:
```bash
uv run benchmark/generate-pure-slop-data-designer.py \
  --num-records 3 \
  --output /tmp/data_designer_prompt_samples_pr_example.jsonl \
  --artifact-dir /tmp/data_designer_prompt_samples_pr_artifacts \
  --dataset-name pr_example_samples
```

Example dataset row excerpt (`text` field):

> Maintaining closeness across long distances is not a mystical art. It is a set
> of intentional habits that anyone can adopt. Start by making communication
> purposeful rather than reactive. Schedule regular check-ins that work for both
> parties, whether that is a brief video call, a daily text thread, or a weekly
> voice memo exchange. The key is not just frequency, but the quality of attention
> in each interaction.
>
> Second, create shared experiences that become joint rituals. Choose a TV series,
> podcast, or book and engage with it together, then discuss it afterward.
> Light-hearted traditions like cooking the same recipe, playing an online game,
> or sending a daily photo can anchor the relationship in a shared narrative.
> Rituals make it clear that both people are investing time and creativity in the
> connection.

## Test Plan
- `uv run benchmark/generate-pure-slop-data-designer.py --help`
- `uv run --with data-designer python - <<'PY' ...` to verify `len(PROMPT_TEMPLATES) == 24` and total topics `== 100`
- `uv run benchmark/generate-pure-slop-data-designer.py --num-records 3 --output /tmp/data_designer_prompt_samples_pr_example.jsonl --artifact-dir /tmp/data_designer_prompt_samples_pr_artifacts --dataset-name pr_example_samples`
- Verify JSONL rows contain a `text` field.
