### PR TITLE
Ignore Markdown blocks in extreme sentence detection

### DIFF
--- a/src/slop_guard/analysis.py
+++ b/src/slop_guard/analysis.py
@@ -110,8 +110,61 @@ _SENTENCE_SPLIT_RE = re.compile(r"[.!?][\"'\u201D\u2019)\]]*(?:\s|$)")
 _BULLET_LINE_RE = re.compile(r"^\s*[-*]\s|^\s*\d+[.)]\s")
 _BOLD_TERM_BULLET_LINE_RE = re.compile(r"^\s*[-*]\s+\*\*|^\s*\d+[.)]\s+\*\*")
 _FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_MARKDOWN_TABLE_DELIMITER_CELL_RE = re.compile(r"^\s*:?-{3,}:?\s*$")
 _WORD_TOKEN_RE = re.compile(r"\w+")
 _EDGE_WORD_STRIP_RE = re.compile(r"^[^\w]+|[^\w]+$")
+
+
+def _split_sentences(text: str) -> tuple[str, ...]:
+    """Return trimmed sentence-like spans from ``text``."""
+    return tuple(s.strip() for s in _SENTENCE_SPLIT_RE.split(text) if s.strip())
+
+
+def _looks_like_markdown_table_row(line: str) -> bool:
+    """Return whether ``line`` looks like a standard pipe-table row."""
+    stripped = line.strip()
+    if "|" not in stripped:
+        return False
+
+    cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+    return len(cells) >= 2 and any(cell for cell in cells)
+
+
+def _is_markdown_table_delimiter(line: str) -> bool:
+    """Return whether ``line`` is a Markdown pipe-table delimiter row."""
+    stripped = line.strip()
+    if "|" not in stripped:
+        return False
+
+    cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+    return len(cells) >= 2 and all(
+        _MARKDOWN_TABLE_DELIMITER_CELL_RE.match(cell) is not None for cell in cells
+    )
+
+
+def _replace_markdown_tables_with_sentence_breaks(text: str) -> str:
+    """Replace standard pipe tables with sentence separators."""
+    lines = text.split("\n")
+    normalized_lines: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if (
+            index + 1 < len(lines)
+            and _looks_like_markdown_table_row(line)
+            and _is_markdown_table_delimiter(lines[index + 1])
+        ):
+            normalized_lines.append(".")
+            index += 2
+            while index < len(lines) and _looks_like_markdown_table_row(lines[index]):
+                index += 1
+            continue
+
+        normalized_lines.append(line)
+        index += 1
+
+    return "\n".join(normalized_lines)
 
 
 @dataclass(frozen=True)
@@ -129,9 +182,7 @@ class AnalysisDocument:
         return cls(
             text=text,
             lines=tuple(text.split("\n")),
-            sentences=tuple(
-                s.strip() for s in _SENTENCE_SPLIT_RE.split(text) if s.strip()
-            ),
+            sentences=_split_sentences(text),
             word_count=word_count(text),
         )
 
@@ -139,6 +190,24 @@ class AnalysisDocument:
     def sentence_word_counts(self) -> tuple[int, ...]:
         """Return cached word counts aligned with ``sentences``."""
         return tuple(len(sentence.split()) for sentence in self.sentences)
+
+    @cached_property
+    def sentence_analysis_text(self) -> str:
+        """Return sentence-analysis text with Markdown blocks replaced."""
+        text_without_code_blocks = _FENCED_CODE_BLOCK_RE.sub("\n.\n", self.text)
+        return _replace_markdown_tables_with_sentence_breaks(text_without_code_blocks)
+
+    @cached_property
+    def sentence_analysis_sentences(self) -> tuple[str, ...]:
+        """Return markdown-sanitized sentences used by sentence-length rules."""
+        return _split_sentences(self.sentence_analysis_text)
+
+    @cached_property
+    def sentence_analysis_word_counts(self) -> tuple[int, ...]:
+        """Return word counts aligned with ``sentence_analysis_sentences``."""
+        return tuple(
+            len(sentence.split()) for sentence in self.sentence_analysis_sentences
+        )
 
     @cached_property
     def lower_text(self) -> str:

--- a/src/slop_guard/rules/passage_level/extreme_sentence_rule.py
+++ b/src/slop_guard/rules/passage_level/extreme_sentence_rule.py
@@ -59,7 +59,10 @@ class ExtremeSentenceRule(Rule[ExtremeSentenceRuleConfig]):
         count = 0
 
         for idx, (sentence, wc) in enumerate(
-            zip(document.sentences, document.sentence_word_counts)
+            zip(
+                document.sentence_analysis_sentences,
+                document.sentence_analysis_word_counts,
+            )
         ):
             if wc >= self.config.min_words:
                 preview = f'"{sentence[:80]}..."' if len(sentence) > 80 else f'"{sentence}"'
@@ -96,7 +99,10 @@ class ExtremeSentenceRule(Rule[ExtremeSentenceRuleConfig]):
 
         def has_extreme(sample: str) -> bool:
             doc = AnalysisDocument.from_text(sample)
-            return any(wc >= self.config.min_words for wc in doc.sentence_word_counts)
+            return any(
+                wc >= self.config.min_words
+                for wc in doc.sentence_analysis_word_counts
+            )
 
         positive_matches = sum(1 for s in positive_samples if has_extreme(s))
         negative_matches = sum(1 for s in negative_samples if has_extreme(s))

--- a/tests/test_analysis_pipeline.py
+++ b/tests/test_analysis_pipeline.py
@@ -66,3 +66,30 @@ def test_analysis_document_cached_views() -> None:
     assert document.word_count_without_code_blocks == word_count(
         document.text_without_code_blocks
     )
+
+
+def test_analysis_document_sentence_analysis_strips_markdown_blocks() -> None:
+    """Sentence analysis should ignore fenced code blocks and pipe tables."""
+    text = (
+        "Intro sentence.\n\n"
+        "```text\n"
+        + " ".join(["code"] * 100)
+        + "\n```\n\n"
+        "| name | details |\n"
+        "| --- | --- |\n"
+        "| alpha | "
+        + " ".join(["cell"] * 40)
+        + " |\n"
+        "| beta | "
+        + " ".join(["cell"] * 40)
+        + " |\n\n"
+        "Closing sentence."
+    )
+    document = AnalysisDocument.from_text(text)
+
+    assert any(word_count >= 80 for word_count in document.sentence_word_counts)
+    assert document.sentence_analysis_sentences == (
+        "Intro sentence",
+        "Closing sentence",
+    )
+    assert document.sentence_analysis_word_counts == (2, 2)

--- a/tests/test_extreme_sentence_rule.py
+++ b/tests/test_extreme_sentence_rule.py
@@ -1,0 +1,77 @@
+"""Tests for Markdown-aware extreme sentence detection."""
+
+
+from slop_guard.analysis import AnalysisDocument
+from slop_guard.rules.passage_level import ExtremeSentenceRule, ExtremeSentenceRuleConfig
+
+
+def _build_rule(min_words: int = 20) -> ExtremeSentenceRule:
+    """Build an extreme-sentence rule with a low threshold for regression tests."""
+    return ExtremeSentenceRule(
+        ExtremeSentenceRuleConfig(
+            min_words=min_words,
+            penalty=-5,
+        )
+    )
+
+
+def test_extreme_sentence_ignores_fenced_code_blocks() -> None:
+    """Code fences should not create run-on sentence violations."""
+    rule = _build_rule()
+    text = (
+        "Intro sentence.\n\n"
+        "```text\n"
+        + " ".join(["code"] * 100)
+        + "\n```\n\n"
+        "Closing sentence."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+    assert result.count_deltas == {}
+
+
+def test_extreme_sentence_ignores_markdown_tables() -> None:
+    """Pipe tables should not count as prose sentences."""
+    rule = _build_rule()
+    rows = "\n".join(
+        f"| row {index} | {' '.join(['cell'] * 8)} |" for index in range(8)
+    )
+    text = (
+        "Intro sentence.\n\n"
+        "| column | details |\n"
+        "| --- | --- |\n"
+        f"{rows}\n\n"
+        "Closing sentence."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+    assert result.count_deltas == {}
+
+
+def test_extreme_sentence_still_flags_long_prose_sentence() -> None:
+    """Actual long prose sentences should still be flagged."""
+    rule = _build_rule()
+    text = " ".join(["word"] * 25) + "."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert len(result.violations) == 1
+    assert result.violations[0].rule == "extreme_sentence"
+    assert result.count_deltas == {"extreme_sentence": 1}
+
+
+def test_extreme_sentence_fit_ignores_markdown_noise() -> None:
+    """Rule fitting should use the same Markdown-sanitized sentence analysis."""
+    rule = _build_rule()
+    samples = [
+        "Short sentence.",
+        "```text\n" + " ".join(["code"] * 100) + "\n```",
+    ]
+
+    fitted_rule = rule.fit(samples, [1, 0])
+
+    assert fitted_rule.config.penalty == 0


### PR DESCRIPTION
## Description

Closes #32.

- add a Markdown-sanitized sentence-analysis view on `AnalysisDocument`
- replace fenced code blocks and standard pipe tables with sentence separators before sentence-length checks
- use the sanitized sentence view in `ExtremeSentenceRule.forward()` and `_fit()`
- add regressions for code fences, tables, actual long prose, and fit-time behavior

## Why?

`extreme_sentence` was counting Markdown code fences and pipe tables as if they were prose. That produced false positive run-on sentence violations on README/docs-heavy workflows, including this repo's `README.md`.

## Usage / Demonstration

Before this change, `uv run sg -j README.md` reported four `extreme_sentence` violations.

After this change, `uv run sg -j README.md` reports no `extreme_sentence` violations, and the README score moves from 26 to 54 because the bogus run-on penalties are gone.

## Test Plan

- `uv run --with pytest pytest -q`
- `uv run sg -j README.md`
- added regressions for fenced code blocks, Markdown pipe tables, real long prose, and fit-time Markdown sanitization
