### PR TITLE
Deduplicate overlapping setup_resolution matches

### DIFF
--- a/src/slop_guard/rules/sentence_level/setup_resolution_rule.py
+++ b/src/slop_guard/rules/sentence_level/setup_resolution_rule.py
@@ -95,9 +95,14 @@ class SetupResolutionRule(Rule[SetupResolutionRuleConfig]):
         violations: list[Violation] = []
         advice: list[str] = []
         count = 0
+        seen_spans: set[tuple[int, int]] = set()
 
         for pattern in (_SETUP_RESOLUTION_A_RE, _SETUP_RESOLUTION_B_RE):
             for match in pattern.finditer(document.text):
+                span = match.span()
+                if span in seen_spans:
+                    continue
+                seen_spans.add(span)
                 if len(violations) < self.config.record_cap:
                     matched_text = match.group(0)
                     violations.append(

--- a/tests/test_setup_resolution_rule.py
+++ b/tests/test_setup_resolution_rule.py
@@ -1,0 +1,33 @@
+"""Tests for setup-resolution rule deduplication behavior."""
+
+
+from slop_guard.analysis import AnalysisDocument, HYPERPARAMETERS
+from slop_guard.rules.sentence_level import SetupResolutionRule, SetupResolutionRuleConfig
+
+
+def _build_rule() -> SetupResolutionRule:
+    """Construct the default setup-resolution rule used in the pipeline."""
+    return SetupResolutionRule(
+        SetupResolutionRuleConfig(
+            penalty=HYPERPARAMETERS.setup_resolution_penalty,
+            record_cap=HYPERPARAMETERS.setup_resolution_record_cap,
+            context_window_chars=HYPERPARAMETERS.context_window_chars,
+        )
+    )
+
+
+def test_setup_resolution_deduplicates_overlapping_pattern_matches() -> None:
+    """Overlapping regex forms should emit one violation per span."""
+    text = (
+        "The system is not just fast, but also scalable. "
+        "This is not about performance. It is about reliability. "
+        "Studies show that holistic monitoring fosters better uptime."
+    )
+
+    result = _build_rule().forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"setup_resolution": 1}
+    assert len(result.violations) == 1
+    assert result.violations[0].rule == "setup_resolution"
+    assert result.violations[0].match == "This is not about performance. It is"
+    assert len(result.advice) == 1


### PR DESCRIPTION
## Description

This change fixes the `setup_resolution` rule so overlapping regex patterns only record one hit for a single text span. The rule still evaluates both pattern families, but it now tracks each matched span before recording a violation, incrementing the count, or appending advice. That preserves the existing detection surface while removing duplicate output for identical matches.

The patch also adds a regression test built from the reported issue text. The test asserts that the rule emits one `setup_resolution` violation, one advice entry, and a count delta of `{"setup_resolution": 1}` for the overlapping case.

## Why?

The previous implementation iterated through `_SETUP_RESOLUTION_A_RE` and `_SETUP_RESOLUTION_B_RE` independently and counted every regex hit. Some sentences satisfy both expressions over the same byte range. That made a single rhetorical turn look like two separate violations and doubled the penalty in CLI and MCP output.

This fix leaves distinct spans alone and suppresses only exact duplicates. If a document contains multiple separate setup-resolution spans, they still count separately.

## Usage / Demonstration

For the reported reproduction case, the rule now emits one `setup_resolution` violation instead of two, and `counts["setup_resolution"]` now reports `1` instead of `2`.

That gives agents and downstream tooling the real number of offending spans instead of an inflated total caused by overlapping regex coverage.

## Test Plan

- `uv run --with pytest pytest -q tests/test_setup_resolution_rule.py tests/test_server_tools.py tests/test_analysis_pipeline.py`
- `uv run --with pytest pytest -q`
- Manual repro with `uv run sg` against the reported sample to confirm one `setup_resolution` violation and a count of `1`
