### PR TITLE
Stabilize MCP counts schema and structural rule keys

### DIFF
--- a/src/slop_guard/analysis.py
+++ b/src/slop_guard/analysis.py
@@ -3,6 +3,7 @@
 
 import math
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Literal, TypeAlias, TypedDict
@@ -326,9 +327,9 @@ class AnalysisState:
     counts: Counts
 
     @classmethod
-    def initial(cls) -> "AnalysisState":
+    def initial(cls, count_keys: Iterable[str] | None = None) -> "AnalysisState":
         """Construct an empty state with canonical counts initialized to zero."""
-        return cls(violations=(), advice=(), counts=initial_counts())
+        return cls(violations=(), advice=(), counts=initial_counts(count_keys))
 
     def merge(self, result: RuleResult) -> "AnalysisState":
         """Merge one rule result into a new state instance."""
@@ -355,20 +356,26 @@ _COUNT_KEYS: tuple[str, ...] = (
     "rhythm",
     "em_dash",
     "contrast_pairs",
+    "setup_resolution",
     "colon_density",
     "pithy_fragment",
-    "setup_resolution",
     "bullet_density",
     "blockquote_density",
     "bold_bullet_list",
     "horizontal_rules",
     "phrase_reuse",
+    "copula_chain",
+    "extreme_sentence",
+    "closing_aphorism",
+    "paragraph_balance",
+    "paragraph_cv",
 )
 
 
-def initial_counts() -> Counts:
+def initial_counts(count_keys: Iterable[str] | None = None) -> Counts:
     """Create the canonical per-rule counter map used by the analyzer."""
-    return {key: 0 for key in _COUNT_KEYS}
+    keys = _COUNT_KEYS if count_keys is None else tuple(dict.fromkeys(count_keys))
+    return {key: 0 for key in keys}
 
 
 def context_around(

--- a/src/slop_guard/rules/paragraph_level/blockquote_density_rule.py
+++ b/src/slop_guard/rules/paragraph_level/blockquote_density_rule.py
@@ -87,7 +87,7 @@ class BlockquoteDensityRule(Rule[BlockquoteDensityRuleConfig]):
         return RuleResult(
             violations=[
                 Violation(
-                    rule=self.name,
+                    rule=self.count_key,
                     match="blockquote_density",
                     context=(
                         f"{blockquote_count} blockquote lines \u2014 Claude uses these "

--- a/src/slop_guard/rules/paragraph_level/bold_term_bullet_run_rule.py
+++ b/src/slop_guard/rules/paragraph_level/bold_term_bullet_run_rule.py
@@ -76,7 +76,7 @@ class BoldTermBulletRunRule(Rule[BoldTermBulletRunRuleConfig]):
             if run >= self.config.min_run_length:
                 violations.append(
                     Violation(
-                        rule=self.name,
+                        rule=self.count_key,
                         match="bold_bullet_list",
                         context=f"Run of {run} bold-term bullets",
                         penalty=self.config.penalty,
@@ -92,7 +92,7 @@ class BoldTermBulletRunRule(Rule[BoldTermBulletRunRuleConfig]):
         if run >= self.config.min_run_length:
             violations.append(
                 Violation(
-                    rule=self.name,
+                    rule=self.count_key,
                     match="bold_bullet_list",
                     context=f"Run of {run} bold-term bullets",
                     penalty=self.config.penalty,

--- a/src/slop_guard/rules/paragraph_level/bullet_density_rule.py
+++ b/src/slop_guard/rules/paragraph_level/bullet_density_rule.py
@@ -72,7 +72,7 @@ class BulletDensityRule(Rule[BulletDensityRuleConfig]):
         return RuleResult(
             violations=[
                 Violation(
-                    rule=self.name,
+                    rule=self.count_key,
                     match="bullet_density",
                     context=(
                         f"{bullet_count} of {total_non_empty} non-empty lines are bullets "

--- a/src/slop_guard/rules/paragraph_level/horizontal_rule_overuse_rule.py
+++ b/src/slop_guard/rules/paragraph_level/horizontal_rule_overuse_rule.py
@@ -72,7 +72,7 @@ class HorizontalRuleOveruseRule(Rule[HorizontalRuleOveruseRuleConfig]):
         return RuleResult(
             violations=[
                 Violation(
-                    rule=self.name,
+                    rule=self.count_key,
                     match="horizontal_rules",
                     context=f"{count} horizontal rules \u2014 excessive section dividers",
                     penalty=self.config.penalty,

--- a/src/slop_guard/rules/pipeline.py
+++ b/src/slop_guard/rules/pipeline.py
@@ -32,6 +32,11 @@ class Pipeline:
         """Initialize a pipeline from an ordered list of instantiated rules."""
         self.rules = list(rules)
 
+    @property
+    def count_keys(self) -> tuple[str, ...]:
+        """Return the ordered count keys used by this pipeline."""
+        return tuple(dict.fromkeys(rule.count_key for rule in self.rules))
+
     @classmethod
     def from_jsonl(cls, path: str | Path | None = None) -> "Pipeline":
         """Build a pipeline from a JSONL rule-settings file.
@@ -60,7 +65,7 @@ class Pipeline:
 
     def forward(self, document: AnalysisDocument) -> AnalysisState:
         """Apply all rules in order and merge their outputs."""
-        state = AnalysisState.initial()
+        state = AnalysisState.initial(self.count_keys)
         for rule in self.rules:
             state = state.merge(rule.forward(document))
         return state

--- a/src/slop_guard/server.py
+++ b/src/slop_guard/server.py
@@ -35,15 +35,16 @@ def _analyze(
 ) -> AnalysisPayload:
     """Run all configured rules and return score, diagnostics, and advice."""
     document = AnalysisDocument.from_text(text)
+    active_pipeline = ACTIVE_PIPELINE if pipeline is None else pipeline
+    count_keys = getattr(active_pipeline, "count_keys", None)
 
     if document.word_count < hyperparameters.short_text_word_count:
         return short_text_result(
             document.word_count,
-            initial_counts(),
+            initial_counts(count_keys),
             hyperparameters,
         )
 
-    active_pipeline = ACTIVE_PIPELINE if pipeline is None else pipeline
     state = active_pipeline.forward(document)
 
     total_penalty = sum(violation.penalty for violation in state.violations)

--- a/tests/test_analysis_pipeline.py
+++ b/tests/test_analysis_pipeline.py
@@ -37,6 +37,38 @@ def test_analyze_short_text_uses_clean_short_circuit() -> None:
     assert result["advice"] == []
 
 
+def test_analyze_short_text_exposes_full_count_schema() -> None:
+    """Short text should still expose the full active count schema."""
+    result = _analyze("Hi there.", HYPERPARAMETERS)
+
+    assert {
+        "closing_aphorism",
+        "copula_chain",
+        "extreme_sentence",
+        "paragraph_balance",
+        "paragraph_cv",
+    }.issubset(result["counts"])
+    assert result["counts"]["closing_aphorism"] == 0
+    assert result["counts"]["paragraph_cv"] == 0
+
+
+def test_structural_subcategory_violations_use_specific_count_keys() -> None:
+    """Structural subcategory violations should align with their count keys."""
+    text = (
+        "Intro line.\n"
+        "- **Reliability** improved\n"
+        "- **Scalability** improved\n"
+        "- **Security** improved\n"
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert result["counts"]["bullet_density"] == 1
+    assert result["counts"]["bold_bullet_list"] == 1
+    assert any(v["rule"] == "bullet_density" for v in result["violations"])
+    assert any(v["rule"] == "bold_bullet_list" for v in result["violations"])
+
+
 def test_analysis_document_cached_views() -> None:
     """AnalysisDocument should expose stable cached projections for reuse."""
     text = (

--- a/tests/test_rule_framework.py
+++ b/tests/test_rule_framework.py
@@ -86,7 +86,10 @@ def test_rule_examples_match_rule_forward_behavior(rule: Rule[RuleConfig]) -> No
 
     for text in violation_examples:
         result = rule.forward(AnalysisDocument.from_text(text))
-        assert any(violation.rule == rule.name for violation in result.violations), (
+        expected_rule_names = {rule.name, rule.count_key}
+        assert any(
+            violation.rule in expected_rule_names for violation in result.violations
+        ), (
             f"{rule.__class__.__name__} expected violation for: {text!r}"
         )
 


### PR DESCRIPTION
## Description

This change stabilizes the MCP `counts` schema and makes structural subcategory violations line up with the keys that appear in `counts`.

On the schema side, the analyzer now initializes `counts` from the active pipeline's `count_key` values instead of relying on a hard-coded subset. That means the response shape includes every active rule key from the configured pipeline, even when a rule does not fire. The short-text fast path now uses the same key set, so short responses and full analyses expose the same schema.

On the violation side, the structural subcategory rules for bullet density, blockquote density, bold-term bullet runs, and horizontal rule overuse now emit their specific `count_key` values in `violations[].rule`. That makes each violation directly addressable through the matching `counts` entry.

The patch also adds regression coverage for both behaviors. The new tests verify that short-text analysis still returns zeroed entries for active passage-level rules such as `copula_chain`, `closing_aphorism`, `extreme_sentence`, `paragraph_balance`, and `paragraph_cv`, and that structural subcategory violations now report rule names like `bullet_density` and `bold_bullet_list`.

## Why?

Downstream MCP consumers need a stable response shape and a reliable way to correlate `violations[].rule` with the `counts` object.

Before this change, several active rule keys only appeared after a violation occurred because the canonical zeroed schema omitted them. That included `copula_chain`, `closing_aphorism`, `extreme_sentence`, `paragraph_balance`, and `paragraph_cv`. In the same area, some structural rules reported the umbrella name `structural` in the violation payload even though the corresponding counters lived under more specific keys. Those two behaviors made schema validation and direct lookup inconsistent.

By deriving the schema from the active pipeline and making the structural subcategory rule names specific, the MCP output now stays aligned with the configured ruleset and is easier for typed consumers to parse.

## Usage / Demonstration

A short-text call such as `check_slop("Hi there.")` now returns the full active `counts` schema with zero values for inactive rules, rather than omitting keys until a rule fires.

A structural-heavy sample now reports violations with rule values such as `bullet_density` and `bold_bullet_list`, and those names map directly to `counts["bullet_density"]` and `counts["bold_bullet_list"]`.

If the active pipeline changes in the future, the zeroed `counts` schema now follows that configured pipeline instead of drifting behind a manually maintained key list.

## Test Plan

- `uv run --with pytest pytest -q tests/test_analysis_pipeline.py tests/test_rule_framework.py tests/test_server_tools.py`
- `uv run --with pytest pytest -q`
- `uv run --with ruff ruff check src tests`
- Manual verification of short-text and structural-subcategory MCP output through `uv run python`
