### PR TITLE
[codex] improve agent advice output

### DIFF
--- a/src/slop_guard/rules/passage_level/rhythm_rule.py
+++ b/src/slop_guard/rules/passage_level/rhythm_rule.py
@@ -98,6 +98,8 @@ class RhythmRule(Rule[RhythmRuleConfig]):
         cv = std / mean
         if cv >= self.config.cv_threshold:
             return RuleResult()
+        shortest = min(lengths)
+        longest = max(lengths)
 
         return RuleResult(
             violations=[
@@ -112,7 +114,12 @@ class RhythmRule(Rule[RhythmRuleConfig]):
                 )
             ],
             advice=[
-                f"Sentence lengths are too uniform (CV={cv:.2f}) \u2014 vary short and long."
+                "Sentence lengths are too uniform "
+                f"(CV={cv:.2f} < {self.config.cv_threshold:.2f}; shortest {shortest} "
+                f"words, longest {longest}, mean {mean:.1f}). Add a much shorter "
+                "or much longer sentence so the passage is not clustered around the "
+                "same length; aim for roughly a 3x spread between the shortest and "
+                "longest sentence."
             ],
             count_deltas={self.count_key: 1},
         )

--- a/src/slop_guard/rules/sentence_level/contrast_pair_rule.py
+++ b/src/slop_guard/rules/sentence_level/contrast_pair_rule.py
@@ -90,13 +90,15 @@ class ContrastPairRule(Rule[ContrastPairRuleConfig]):
                 )
             )
             advice.append(
-                f"'{snippet}' \u2014 'X, not Y' contrast \u2014 consider rephrasing to avoid the Claude pattern."
+                f"Rewrite '{snippet}' as a plain sentence with the actual claim "
+                "instead of an 'X, not Y' slogan."
             )
 
         if len(matches) >= self.config.advice_min:
             advice.append(
-                f"{len(matches)} 'X, not Y' contrasts \u2014 this is a Claude rhetorical tic. "
-                "Vary your phrasing."
+                f"{len(matches)} 'X, not Y' contrasts \u2014 stop stacking slogan-like "
+                "oppositions; rewrite at least one as a plain sentence with the actual "
+                "tradeoff."
             )
 
         return RuleResult(

--- a/src/slop_guard/rules/sentence_level/pithy_fragment_rule.py
+++ b/src/slop_guard/rules/sentence_level/pithy_fragment_rule.py
@@ -90,8 +90,8 @@ class PithyFragmentRule(Rule[PithyFragmentRuleConfig]):
                     )
                 )
                 advice.append(
-                    f"'{sentence_text}' \u2014 pithy evaluative fragments are a Claude tell. "
-                    "Expand or cut."
+                    f"Rewrite '{sentence_text}' as a plain sentence with the actual "
+                    "claim, or cut it if it adds no detail."
                 )
             count += 1
 

--- a/src/slop_guard/rules/sentence_level/slop_phrase_rule.py
+++ b/src/slop_guard/rules/sentence_level/slop_phrase_rule.py
@@ -144,6 +144,60 @@ _SLOP_PHRASES_RE_LIST: tuple[re.Pattern[str], ...] = tuple(
 _NOT_JUST_BUT_RE = re.compile(
     r"not (just|only) .{1,40}, but (also )?", re.IGNORECASE
 )
+_INTERACTIVE_SLOP_PHRASES: frozenset[str] = frozenset(
+    {
+        "as i mentioned",
+        "as mentioned earlier",
+        "feel free to",
+        "here are a few options",
+        "here are some options",
+        "i can adapt this",
+        "i can also",
+        "i can make this",
+        "i hope this helps",
+        "if you'd like, i can",
+        "if you want, i can",
+        "let me know if",
+        "shall i",
+        "would you like me to",
+        "would you prefer",
+    }
+)
+_ANNOUNCEMENT_SLOP_PHRASES: frozenset[str] = frozenset(
+    {
+        "everything changed",
+        "something shifted",
+        "the answer? it's simpler than you think",
+        "this is where things get interesting",
+    }
+)
+_TRANSITION_SLOP_PHRASES: frozenset[str] = frozenset(
+    {
+        "in addition",
+        "in conclusion",
+        "in other words",
+        "in summary",
+        "on the other hand",
+        "put differently",
+        "that is to say",
+        "to put it another way",
+        "to put it simply",
+    }
+)
+
+
+def _slop_phrase_advice(phrase: str) -> str:
+    """Return rewrite guidance tuned to the phrase's rhetorical role."""
+    if phrase in _INTERACTIVE_SLOP_PHRASES:
+        return f"Cut '{phrase}' — replace the invitation with the actual point."
+    if phrase in _ANNOUNCEMENT_SLOP_PHRASES:
+        return f"Cut '{phrase}' — replace the announcement with the actual point."
+    if phrase in _TRANSITION_SLOP_PHRASES:
+        return (
+            f"Cut '{phrase}' — start the sentence directly or show the relationship "
+            "with the content itself."
+        )
+    return f"Cut '{phrase}' — replace the setup with the actual point."
 
 
 @dataclass
@@ -213,9 +267,7 @@ class SlopPhraseRule(Rule[SlopPhraseRuleConfig]):
                             penalty=self.config.penalty,
                         )
                     )
-                    advice.append(
-                        f"Cut '{phrase}' \u2014 just state the point directly."
-                    )
+                    advice.append(_slop_phrase_advice(phrase))
                     count += 1
                     start = hit_end
         else:
@@ -235,9 +287,7 @@ class SlopPhraseRule(Rule[SlopPhraseRuleConfig]):
                             penalty=self.config.penalty,
                         )
                     )
-                    advice.append(
-                        f"Cut '{phrase}' \u2014 just state the point directly."
-                    )
+                    advice.append(_slop_phrase_advice(phrase))
                     count += 1
 
         if (
@@ -261,7 +311,7 @@ class SlopPhraseRule(Rule[SlopPhraseRuleConfig]):
                     )
                 )
                 advice.append(
-                    f"Cut '{phrase}' \u2014 just state the point directly."
+                    f"Cut '{phrase}' — replace the setup with the actual point."
                 )
                 count += 1
 

--- a/src/slop_guard/rules/sentence_level/tone_marker_rule.py
+++ b/src/slop_guard/rules/sentence_level/tone_marker_rule.py
@@ -62,6 +62,16 @@ _SENTENCE_OPENER_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+def _meta_comm_advice(phrase: str) -> str:
+    """Return a canonical rewrite for invitation-style assistant phrasing."""
+    return f"Cut '{phrase}' — replace the invitation with the actual point."
+
+
+def _false_narrativity_advice(phrase: str) -> str:
+    """Return a canonical rewrite for dramatic setup phrasing."""
+    return f"Cut '{phrase}' — replace the announcement with the actual point."
+
+
 @dataclass
 class ToneMarkerRuleConfig(RuleConfig):
     """Config for tone marker pattern matching."""
@@ -121,9 +131,7 @@ class ToneMarkerRule(Rule[ToneMarkerRuleConfig]):
                             penalty=self.config.tone_penalty,
                         )
                     )
-                    advice.append(
-                        f"Remove '{phrase}' \u2014 this is a direct AI tell."
-                    )
+                    advice.append(_meta_comm_advice(phrase))
                     count += 1
                     start = hit_end
 
@@ -148,9 +156,7 @@ class ToneMarkerRule(Rule[ToneMarkerRuleConfig]):
                             penalty=self.config.tone_penalty,
                         )
                     )
-                    advice.append(
-                        f"Cut '{phrase}' \u2014 announce less, show more."
-                    )
+                    advice.append(_false_narrativity_advice(phrase))
                     count += 1
                     start = hit_end
         else:
@@ -170,9 +176,7 @@ class ToneMarkerRule(Rule[ToneMarkerRuleConfig]):
                             penalty=self.config.tone_penalty,
                         )
                     )
-                    advice.append(
-                        f"Remove '{phrase}' \u2014 this is a direct AI tell."
-                    )
+                    advice.append(_meta_comm_advice(phrase))
                     count += 1
 
             for pattern in _FALSE_NARRATIVITY_PATTERNS:
@@ -191,9 +195,7 @@ class ToneMarkerRule(Rule[ToneMarkerRuleConfig]):
                             penalty=self.config.tone_penalty,
                         )
                     )
-                    advice.append(
-                        f"Cut '{phrase}' \u2014 announce less, show more."
-                    )
+                    advice.append(_false_narrativity_advice(phrase))
                     count += 1
 
         if "certainly" in document.lower_text or "absolutely" in document.lower_text:
@@ -214,7 +216,7 @@ class ToneMarkerRule(Rule[ToneMarkerRuleConfig]):
                         )
                     )
                     advice.append(
-                        f"'{word}' as a sentence opener is an AI tell \u2014 just make the point."
+                        f"Cut '{word}' as a sentence opener — just make the point."
                     )
                     count += 1
 

--- a/src/slop_guard/rules/word_level/slop_word_rule.py
+++ b/src/slop_guard/rules/word_level/slop_word_rule.py
@@ -20,6 +20,7 @@ language and accumulate penalty quickly.
 """
 
 
+from collections import Counter
 import re
 from dataclasses import dataclass
 
@@ -135,10 +136,54 @@ _PLAIN_SLOP_WORDS: frozenset[str] = frozenset(
 _HYPHENATED_SLOP_WORDS: tuple[str, ...] = tuple(
     word for word in _ALL_SLOP_WORDS if "-" in word
 )
+_SLOP_ADJECTIVE_SET: frozenset[str] = frozenset(_SLOP_ADJECTIVES)
+_SLOP_VERB_SET: frozenset[str] = frozenset(_SLOP_VERBS)
+_SLOP_HEDGE_SET: frozenset[str] = frozenset(_SLOP_HEDGE)
+_SLOP_SYSTEM_NOUNS: frozenset[str] = frozenset(
+    {"ecosystem", "landscape", "nexus", "realm", "spectrum", "symphony", "tapestry"}
+)
+_SLOP_TIMELINE_NOUNS: frozenset[str] = frozenset(
+    {"journey", "narrative", "odyssey", "trajectory"}
+)
 _SLOP_WORD_RE = re.compile(
     r"\b(" + "|".join(re.escape(word) for word in _ALL_SLOP_WORDS) + r")\b",
     re.IGNORECASE,
 )
+
+
+def _occurrence_suffix(count: int) -> str:
+    """Return a stable occurrence suffix for grouped advice lines."""
+    if count <= 1:
+        return ""
+    return f" ({count} occurrences)"
+
+
+def _slop_word_advice(word: str, count: int) -> str:
+    """Return category-specific rewrite advice for a matched slop word."""
+    suffix = _occurrence_suffix(count)
+    if word in _SLOP_HEDGE_SET:
+        return (
+            f"Cut '{word}'{suffix} — start the sentence directly or show the "
+            "connection without announcing it."
+        )
+    if word in _SLOP_VERB_SET:
+        return (
+            f"Replace '{word}'{suffix} with the specific action, result, or evidence."
+        )
+    if word in _SLOP_SYSTEM_NOUNS:
+        return (
+            f"Replace '{word}'{suffix} with the concrete system, group, or thing you mean."
+        )
+    if word in _SLOP_TIMELINE_NOUNS:
+        return (
+            f"Replace '{word}'{suffix} with the actual period, step, or change you observed."
+        )
+    if word in _SLOP_ADJECTIVE_SET:
+        return (
+            f"Cut '{word}'{suffix} unless you can name the concrete property, metric, "
+            "or consequence."
+        )
+    return f"Replace '{word}'{suffix} with the concrete object, event, or claim."
 
 
 @dataclass
@@ -173,7 +218,8 @@ class SlopWordRule(Rule[SlopWordRuleConfig]):
     def forward(self, document: AnalysisDocument) -> RuleResult:
         """Apply the slop-word detector to the full text."""
         violations: list[Violation] = []
-        advice: list[str] = []
+        word_counts: Counter[str] = Counter()
+        advice_order: list[str] = []
         count = 0
 
         has_plain_slop_token = bool(document.word_token_set_lower & _PLAIN_SLOP_WORDS)
@@ -198,14 +244,14 @@ class SlopWordRule(Rule[SlopWordRuleConfig]):
                     penalty=self.config.penalty,
                 )
             )
-            advice.append(
-                f"Replace '{word}' \u2014 what specifically do you mean?"
-            )
+            if word_counts[word] == 0:
+                advice_order.append(word)
+            word_counts[word] += 1
             count += 1
 
         return RuleResult(
             violations=violations,
-            advice=advice,
+            advice=[_slop_word_advice(word, word_counts[word]) for word in advice_order],
             count_deltas={self.count_key: count} if count else {},
         )
 

--- a/tests/test_advice_updates.py
+++ b/tests/test_advice_updates.py
@@ -1,0 +1,117 @@
+"""Regression tests for agent-facing advice strings."""
+
+
+from slop_guard.analysis import HYPERPARAMETERS
+from slop_guard.server import _analyze
+
+
+def test_slop_word_advice_uses_category_specific_templates() -> None:
+    """Slop-word advice should reflect the word's rhetorical role."""
+    text = (
+        "Furthermore, the innovative team shipped an innovative feature. "
+        "However, the journey took months."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert (
+        "Cut 'furthermore' — start the sentence directly or show the connection "
+        "without announcing it."
+    ) in result["advice"]
+    assert (
+        "Cut 'innovative' (2 occurrences) unless you can name the concrete "
+        "property, metric, or consequence."
+    ) in result["advice"]
+    assert (
+        "Cut 'however' — start the sentence directly or show the connection "
+        "without announcing it."
+    ) in result["advice"]
+    assert (
+        "Replace 'journey' with the actual period, step, or change you observed."
+    ) in result["advice"]
+
+
+def test_repeated_slop_words_report_occurrence_counts_in_advice() -> None:
+    """Grouped advice should say how many times a repeated slop word appears."""
+    text = (
+        "Innovative teams built innovative tools with innovative methods. "
+        "Their innovative plan used innovative demos for innovative launches."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert result["advice"] == [
+        "Cut 'innovative' (6 occurrences) unless you can name the concrete "
+        "property, metric, or consequence."
+    ]
+
+
+def test_rhythm_advice_reports_threshold_and_sentence_range() -> None:
+    """Rhythm advice should report the current gap instead of a vague prompt."""
+    text = (
+        "One two three four. "
+        "Five six seven eight. "
+        "Nine ten eleven twelve. "
+        "Thirteen fourteen fifteen sixteen. "
+        "Seventeen eighteen nineteen twenty."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert result["advice"] == [
+        "Sentence lengths are too uniform (CV=0.00 < 0.30; shortest 4 words, "
+        "longest 4, mean 4.0). Add a much shorter or much longer sentence so "
+        "the passage is not clustered around the same length; aim for roughly "
+        "a 3x spread between the shortest and longest sentence."
+    ]
+
+
+def test_overlapping_phrase_rules_share_one_canonical_edit_message() -> None:
+    """Overlapping phrase and tone rules should deduplicate shared guidance."""
+    text = (
+        "The metrics looked stable at first today. "
+        "This is where things get interesting. "
+        "Let me know if you want the rollback details after tomorrow morning."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert (
+        result["advice"].count(
+            "Cut 'this is where things get interesting' — replace the announcement "
+            "with the actual point."
+        )
+        == 1
+    )
+    assert (
+        result["advice"].count(
+            "Cut 'let me know if' — replace the invitation with the actual point."
+        )
+        == 1
+    )
+
+
+def test_contrast_and_pithy_fragment_advice_use_the_same_rewrite_direction() -> None:
+    """Contrast and fragment rules should point toward the same edit action."""
+    text = (
+        "This is focus, not frenzy. "
+        "It is clarity, not complexity. "
+        "The deploy finished yesterday after two routine checks."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert (
+        "Rewrite 'focus, not frenzy' as a plain sentence with the actual claim "
+        "instead of an 'X, not Y' slogan."
+    ) in result["advice"]
+    assert (
+        "Rewrite 'This is focus, not frenzy' as a plain sentence with the actual "
+        "claim, or cut it if it adds no detail."
+    ) in result["advice"]
+    assert (
+        "2 'X, not Y' contrasts — stop stacking slogan-like oppositions; rewrite "
+        "at least one as a plain sentence with the actual tradeoff."
+    ) in result["advice"]
+    assert all("consider rephrasing" not in item for item in result["advice"])
+    assert all("Expand or cut." not in item for item in result["advice"])


### PR DESCRIPTION
## Description

This change makes slop-word advice depend on the word's role, adds occurrence counts for repeated slop words, expands rhythm advice with the current CV gap and sentence-length range, and aligns overlapping phrase and tone guidance plus contrast and pithy-fragment guidance around a single rewrite action. It also adds regression tests for the issue examples behind the update.

## Why?

The existing advice output is often too vague or internally inconsistent for an agent to fix in one pass. Repeated slop words collapse into one opaque instruction, connective markers get the wrong rewrite prompt, and overlapping rules can suggest different edits for the same span.

Closes #37
Closes #38
Closes #39
Closes #46
Closes #47

## Usage / Demonstration

Run `uv run --with pytest pytest tests/test_advice_updates.py` to exercise the new advice regressions. The updated output now tells the agent to drop connective filler and start directly, reports repeated-word counts such as `term repeated 6 times`, and includes the measured CV, threshold, and sentence-length range when rhythm fails.

## Test Plan

Ran `uv run --with pytest pytest`.
