### PR TITLE
Distinguish development versions from full releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -29,7 +31,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
-          PROJECT_VERSION="$(uv version --short)"
+          PROJECT_VERSION="$(uv run python -c 'from importlib.metadata import version; print(version("slop-guard"))')"
           if [ "${TAG_VERSION}" != "${PROJECT_VERSION}" ]; then
             echo "Tag version (${TAG_VERSION}) does not match project version (${PROJECT_VERSION})."
             exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.27.0"]
+requires = ["hatch-vcs>=0.4.0", "hatchling>=1.27.0"]
 build-backend = "hatchling.build"
 
 [project]
 name = "slop-guard"
-version = "0.3.1"
+dynamic = ["version"]
 description = "Rule-based prose linter for formulaic AI writing patterns."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -72,6 +72,9 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/slop_guard"]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -779,7 +779,6 @@ wheels = [
 
 [[package]]
 name = "slop-guard"
-version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Description

This PR replaces the static `0.3.1` project version with VCS-derived package metadata from the repository's existing `v*` tags. A checkout on a tagged release still resolves to the plain release version, while a checkout from `main` or any other post-tag commit resolves to a PEP 440 development version. That means the CLI version flags now distinguish development installs from full releases.

It also updates the publish workflow so release verification still works with dynamic versions. The job now fetches full git history and compares the release tag to installed package metadata instead of calling `uv version --short`, which rejects dynamic project versions.

## Why?

The CLI currently prints the same static version string for both released builds and local development installs. That makes it hard to confirm that a machine is using the current `main` checkout instead of the last tagged release, and it leaves the publish workflow coupled to static project metadata.

## Usage / Demonstration

```bash
uv run sg --version
uv run slop-guard --version
uv run sg-fit --version

# each command printed:
# 0.3.1.dev27+g5415738d0.d20260327
```

On a tagged checkout such as `v0.3.1`, the same metadata path resolves to the plain release version `0.3.1`.

## Verification

I ran `uv lock`, refreshed the editable install with `uv sync`, checked all three CLI `--version` entry points, ran `uv run pytest`, and built both distributions with `uv build`.

## Issues

- None.
