### PR TITLE
Add character offsets to violation payloads

### DIFF
--- a/src/slop_guard/analysis.py
+++ b/src/slop_guard/analysis.py
@@ -9,8 +9,19 @@ from functools import cached_property
 from typing import Literal, TypeAlias, TypedDict
 
 Counts: TypeAlias = dict[str, int]
-ViolationPayload: TypeAlias = dict[str, object]
 BandLabel: TypeAlias = Literal["clean", "light", "moderate", "heavy", "saturated"]
+
+
+class ViolationPayload(TypedDict):
+    """Structured violation payload returned to CLI and MCP consumers."""
+
+    type: Literal["Violation"]
+    rule: str
+    match: str
+    context: str
+    penalty: int
+    start: int
+    end: int
 
 
 class AnalysisPayload(TypedDict):
@@ -116,8 +127,16 @@ class Violation:
     match: str
     context: str
     penalty: int
+    start: int | None = None
+    end: int | None = None
 
-    def to_payload(self) -> ViolationPayload:
+    def explicit_span(self) -> tuple[int, int] | None:
+        """Return the exact rule-provided span when one exists."""
+        if self.start is None or self.end is None:
+            return None
+        return (self.start, self.end)
+
+    def to_payload(self, start: int, end: int) -> ViolationPayload:
         """Serialize a typed violation for tool output."""
         return {
             "type": "Violation",
@@ -125,6 +144,8 @@ class Violation:
             "match": self.match,
             "context": self.context,
             "penalty": self.penalty,
+            "start": start,
+            "end": end,
         }
 
 
@@ -393,6 +414,114 @@ def context_around(
     prefix = "..." if ctx_start > 0 else ""
     suffix = "..." if ctx_end < len(text) else ""
     return f"{prefix}{snippet}{suffix}"
+
+
+def _literal_span_candidates(text: str, match: str) -> tuple[tuple[int, int], ...]:
+    """Return case-insensitive exact-text match spans for ``match``."""
+    if not match:
+        return ()
+    return tuple(
+        (occurrence.start(), occurrence.end())
+        for occurrence in re.finditer(re.escape(match), text, flags=re.IGNORECASE)
+    )
+
+
+def _context_core(context: str) -> str:
+    """Return the searchable body of a context snippet without ellipses."""
+    start = 3 if context.startswith("...") else 0
+    end = len(context) - 3 if context.endswith("...") else len(context)
+    return context[start:end]
+
+
+def _context_span_candidates(
+    normalized_text: str,
+    context: str,
+) -> tuple[tuple[int, int], ...]:
+    """Return spans where the normalized context snippet occurs in ``text``."""
+    core = _context_core(context)
+    if not core:
+        return ()
+
+    spans: list[tuple[int, int]] = []
+    start = 0
+    while True:
+        index = normalized_text.find(core, start)
+        if index < 0:
+            return tuple(spans)
+        spans.append((index, index + len(core)))
+        start = index + 1
+
+
+def _select_unused_span(
+    candidates: tuple[tuple[int, int], ...],
+    used_spans: set[tuple[int, int]],
+) -> tuple[int, int] | None:
+    """Return the first candidate span not already used, else the first match."""
+    for span in candidates:
+        if span not in used_spans:
+            return span
+    return candidates[0] if candidates else None
+
+
+def _resolve_violation_span(
+    violation: Violation,
+    text: str,
+    normalized_text: str,
+    context_window_chars: int,
+    used_spans: set[tuple[int, int]],
+) -> tuple[int, int]:
+    """Resolve a best-effort character span for a violation payload."""
+    explicit_span = violation.explicit_span()
+    if explicit_span is not None:
+        return explicit_span
+
+    literal_candidates = _literal_span_candidates(text, violation.match)
+    context_matched_literal_candidates = tuple(
+        span
+        for span in literal_candidates
+        if context_around(text, span[0], span[1], context_window_chars) == violation.context
+    )
+    literal_span = _select_unused_span(context_matched_literal_candidates, used_spans)
+    if literal_span is not None:
+        return literal_span
+
+    if violation.match.casefold() in violation.context.casefold():
+        literal_span = _select_unused_span(literal_candidates, used_spans)
+        if literal_span is not None:
+            return literal_span
+
+    context_span = _select_unused_span(
+        _context_span_candidates(normalized_text, violation.context),
+        used_spans,
+    )
+    if context_span is not None:
+        return context_span
+
+    return (0, len(text))
+
+
+def serialize_violations(
+    violations: Iterable[Violation],
+    text: str,
+    context_window_chars: int,
+) -> list[ViolationPayload]:
+    """Serialize violations and attach resolved character offsets."""
+    normalized_text = text.replace("\n", " ")
+    used_spans: set[tuple[int, int]] = set()
+    payloads: list[ViolationPayload] = []
+
+    for violation in violations:
+        start, end = _resolve_violation_span(
+            violation,
+            text,
+            normalized_text,
+            context_window_chars,
+            used_spans,
+        )
+        used_spans.add((start, end))
+        payloads.append(violation.to_payload(start, end))
+
+    return payloads
 
 
 def word_count(text: str) -> int:

--- a/src/slop_guard/server.py
+++ b/src/slop_guard/server.py
@@ -16,6 +16,7 @@ from .analysis import (
     compute_weighted_sum,
     deduplicate_advice,
     initial_counts,
+    serialize_violations,
     score_from_density,
     short_text_result,
 )
@@ -65,7 +66,11 @@ def _analyze(
         "score": score,
         "band": band,
         "word_count": document.word_count,
-        "violations": [violation.to_payload() for violation in state.violations],
+        "violations": serialize_violations(
+            state.violations,
+            document.text,
+            hyperparameters.context_window_chars,
+        ),
         "counts": state.counts,
         "total_penalty": total_penalty,
         "weighted_sum": round(weighted_sum, 2),
@@ -79,7 +84,8 @@ def check_slop(text: str) -> AnalysisPayload:
     """Analyze text for AI slop patterns.
 
     Returns a JSON object with a score (0-100), band label, list of specific
-    violations with context, and actionable advice for each issue found.
+    violations with context and character offsets, and actionable advice for
+    each issue found.
     """
     return _analyze(text, HYPERPARAMETERS)
 
@@ -114,7 +120,8 @@ def check_slop_file(file_path: str) -> FileAnalysisPayload:
 
     Reads the file at the given path and runs the same analysis as check_slop.
     Returns a JSON object with a score (0-100), band label, list of specific
-    violations with context, and actionable advice for each issue found.
+    violations with context and character offsets, and actionable advice for
+    each issue found.
     """
     text = _read_analysis_file(file_path)
     result = _analyze(text, HYPERPARAMETERS)

--- a/tests/test_analysis_pipeline.py
+++ b/tests/test_analysis_pipeline.py
@@ -29,6 +29,54 @@ def test_analyze_runs_instantiated_rule_pipeline() -> None:
     assert any(v["rule"] == "slop_word" for v in result["violations"])
 
 
+def test_analyze_repeated_literal_violations_get_distinct_offsets() -> None:
+    """Repeated literal matches should serialize distinct character spans."""
+    text = (
+        "Alpha crucial beta gamma delta epsilon zeta eta theta iota kappa "
+        "crucial lambda."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+    crucial_violations = [
+        violation
+        for violation in result["violations"]
+        if violation["rule"] == "slop_word" and violation["match"] == "crucial"
+    ]
+
+    assert len(crucial_violations) == 2
+    spans = [
+        (int(violation["start"]), int(violation["end"]))
+        for violation in crucial_violations
+    ]
+    assert spans[0] != spans[1]
+    assert [text[start:end].lower() for start, end in spans] == [
+        "crucial",
+        "crucial",
+    ]
+
+
+def test_analyze_aggregate_violations_fall_back_to_document_offsets() -> None:
+    """Aggregate findings should still expose a deterministic edit span."""
+    text = (
+        "- alpha item\n"
+        "- beta item\n"
+        "- gamma item\n"
+        "Summary line with enough filler words to avoid a short-text bypass.\n"
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+    bullet_density_violation = next(
+        violation
+        for violation in result["violations"]
+        if violation["rule"] == "bullet_density"
+    )
+
+    assert (
+        bullet_density_violation["start"],
+        bullet_density_violation["end"],
+    ) == (0, len(text))
+
+
 def test_analyze_short_text_uses_clean_short_circuit() -> None:
     """Short text should preserve score and payload defaults."""
     result = _analyze("too short", HYPERPARAMETERS)

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -23,6 +23,24 @@ def test_check_slop_tool_returns_structured_output(mcp_tool, run_mcp_tool) -> No
     assert "score" in tool.output_schema["properties"]
 
 
+def test_check_slop_tool_includes_violation_offsets(run_mcp_tool) -> None:
+    """``check_slop`` violations should include direct character offsets."""
+    text = (
+        "Alpha crucial beta gamma delta epsilon zeta eta theta iota kappa "
+        "crucial lambda."
+    )
+
+    _content, structured = run_mcp_tool("check_slop", {"text": text})
+
+    violation = next(
+        item for item in structured["violations"] if item["rule"] == "slop_word"
+    )
+
+    assert isinstance(violation["start"], int)
+    assert isinstance(violation["end"], int)
+    assert text[violation["start"] : violation["end"]].lower() == violation["match"]
+
+
 def test_check_slop_file_tool_returns_structured_output(
     write_text_file,
     run_mcp_tool,


### PR DESCRIPTION
## Description

This PR adds `start` and `end` character offsets to every violation returned by `check_slop` and `check_slop_file`. The analyzer now serializes each violation with a direct span, using exact rule-provided offsets when available, then resolving spans from literal matches or context snippets, and falling back to the full analyzed document for aggregate findings that do not map to one exact substring.

## Why?

Issue #40 points out that agents currently have to re-search the source text to find each violation before editing. That extra search step is unnecessary for literal findings and ambiguous for repeated phrases. Returning offsets from slop-guard makes automated rewrites simpler and keeps the lookup logic in one place instead of pushing it onto every client.

## Usage / Demonstration

Before this change, a violation payload looked like this:

```json
{
  "type": "Violation",
  "rule": "example_rule",
  "match": "token",
  "context": "Alpha token beta.",
  "penalty": -2
}
```

After this change, the payload includes a direct edit span:

```json
{
  "type": "Violation",
  "rule": "example_rule",
  "match": "token",
  "context": "Alpha token beta.",
  "penalty": -2,
  "start": 6,
  "end": 11
}
```

Clients can now apply a replacement directly:

```python
updated = text[:violation["start"]] + replacement + text[violation["end"]:]
```

Aggregate findings such as bullet-density or passage-rhythm still receive offsets. When a rule does not identify one exact substring, the payload points at the full analyzed document so clients still receive a deterministic span.

## Verification

- `uv run pytest`

## Issues

- Closes #40
