### PR TITLE
Stop flagging standard transition words as slop words

### DIFF
--- a/src/slop_guard/rules/word_level/slop_word_rule.py
+++ b/src/slop_guard/rules/word_level/slop_word_rule.py
@@ -113,19 +113,13 @@ _SLOP_NOUNS = (
 )
 
 _SLOP_HEDGE = (
-    "notably",
-    "importantly",
-    "furthermore",
-    "additionally",
-    "particularly",
+    # Keep routine transitions like "however" and "furthermore" out of this
+    # list. They are standard connective prose, not AI-slop markers.
     "significantly",
     "interestingly",
     "remarkably",
     "surprisingly",
     "fascinatingly",
-    "moreover",
-    "however",
-    "overall",
     "subtly",
 )
 
@@ -213,6 +207,7 @@ class SlopWordRule(Rule[SlopWordRuleConfig]):
         return [
             "This patch removes an O(n^2) loop in parsing.",
             "P95 latency dropped from 180 ms to 95 ms after batching writes.",
+            "However, three reports still need one indexed join.",
         ]
 
     def forward(self, document: AnalysisDocument) -> RuleResult:

--- a/tests/test_advice_updates.py
+++ b/tests/test_advice_updates.py
@@ -1,6 +1,8 @@
 """Regression tests for agent-facing advice strings."""
 
 
+import pytest
+
 from slop_guard.analysis import HYPERPARAMETERS
 from slop_guard.server import _analyze
 
@@ -8,23 +10,19 @@ from slop_guard.server import _analyze
 def test_slop_word_advice_uses_category_specific_templates() -> None:
     """Slop-word advice should reflect the word's rhetorical role."""
     text = (
-        "Furthermore, the innovative team shipped an innovative feature. "
-        "However, the journey took months."
+        "Remarkably, the innovative team shipped an innovative feature. "
+        "The journey took months."
     )
 
     result = _analyze(text, HYPERPARAMETERS)
 
     assert (
-        "Cut 'furthermore' — start the sentence directly or show the connection "
+        "Cut 'remarkably' — start the sentence directly or show the connection "
         "without announcing it."
     ) in result["advice"]
     assert (
         "Cut 'innovative' (2 occurrences) unless you can name the concrete "
         "property, metric, or consequence."
-    ) in result["advice"]
-    assert (
-        "Cut 'however' — start the sentence directly or show the connection "
-        "without announcing it."
     ) in result["advice"]
     assert (
         "Replace 'journey' with the actual period, step, or change you observed."
@@ -44,6 +42,35 @@ def test_repeated_slop_words_report_occurrence_counts_in_advice() -> None:
         "Cut 'innovative' (6 occurrences) unless you can name the concrete "
         "property, metric, or consequence."
     ]
+
+
+@pytest.mark.parametrize(
+    "transition_word",
+    (
+        "however",
+        "overall",
+        "furthermore",
+        "additionally",
+        "moreover",
+        "particularly",
+        "notably",
+        "importantly",
+    ),
+)
+def test_standard_transition_words_do_not_trigger_slop_word_violations(
+    transition_word: str,
+) -> None:
+    """Common transition words should not be treated as slop words."""
+    text = (
+        "The migration completed on schedule. "
+        f"{transition_word.capitalize()}, three reports still need one indexed join."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert result["score"] == HYPERPARAMETERS.score_max
+    assert result["violations"] == []
+    assert result["advice"] == []
 
 
 def test_rhythm_advice_reports_threshold_and_sentence_range() -> None:


### PR DESCRIPTION
## Description

This change removes eight routine transition words from the `SlopWordRule` hedge list and adds regression coverage that keeps them out of `slop_word` violations. The tests still cover hedge-specific advice by using a remaining rhetorical marker, and the rule examples now include a sentence-initial `However` as a non-violation.

## Why?

Issue #50 shows that one sentence-initial `However` in clean technical prose can drop the analyzer to `34 heavy`. Those connective adverbs are normal English, so treating them as slop makes the score noisy and the rewrite advice wrong.

## Usage / Demonstration

```bash
cat > /tmp/issue50_however.txt <<'TXT'
The migration completed on schedule. The new schema reduces storage costs by fifteen percent and eliminates the need for the overnight compaction job that had been running since 2019. Query latency improved for most endpoints. However, three reports that join across the accounts and transactions tables now take twice as long because the denormalized columns they relied on were removed. The team is building materialized views to restore those query paths before the next release.
TXT
uv run sg -v /tmp/issue50_however.txt
# /tmp/issue50_however.txt: 100/100 [clean] (75 words) .
```

## Verification

- `uv run pytest`
- `uv run pytest tests/test_advice_updates.py tests/test_rule_framework.py tests/test_analysis_pipeline.py`
- `uv run sg -v /tmp/issue50_however.txt`

## Issues

- Closes #50
