### PR TITLE
Add a minimum word floor to score density

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ They also flag contrast/setup-resolution tells, pithy fragments, repeated 4-8 wo
 
 Texts under 10 words are skipped and return a clean `100`.
 
-Otherwise scoring uses exponential decay: `score = 100 * exp(-lambda * density)`, where density is the weighted penalty sum normalized per 1000 words. Claude-specific categories (contrast pairs, setup-resolution, pithy fragments) get a concentration multiplier. Repeated use of the same tic costs more than diverse violations.
+Otherwise scoring uses exponential decay: `score = 100 * exp(-lambda * density)`, where density is the weighted penalty sum normalized per 1000 effective words with a 200-word minimum denominator floor. Claude-specific categories (contrast pairs, setup-resolution, pithy fragments) get a concentration multiplier. Repeated use of the same tic costs more than diverse violations.
 
 ## Scoring bands
 
@@ -252,7 +252,7 @@ violations     array of {type, rule, match, context, penalty}
 counts         per-category violation counts
 total_penalty  sum of all penalty values
 weighted_sum   after concentration multiplier
-density        weighted_sum per 1000 words
+density        weighted_sum per 1000 effective words (min 200-word floor)
 advice         array of advice strings, one per distinct issue
 ```
 

--- a/src/slop_guard/analysis.py
+++ b/src/slop_guard/analysis.py
@@ -108,6 +108,7 @@ class Hyperparameters:
     phrase_reuse_penalty: int = -1
 
     density_words_basis: float = 1000.0
+    density_min_word_count: int = 200
     score_min: int = 0
     score_max: int = 100
     band_clean_min: int = 80
@@ -568,6 +569,28 @@ def compute_weighted_sum(
             weight = penalty
         weighted_sum += weight
     return weighted_sum
+
+
+def density_from_weighted_sum(
+    weighted_sum: float,
+    word_count_value: int,
+    hp: Hyperparameters,
+) -> float:
+    """Normalize weighted penalties into score density.
+
+    Args:
+        weighted_sum: Absolute penalty mass after concentration multipliers.
+        word_count_value: Observed document word count.
+        hp: Analyzer hyperparameters.
+
+    Returns:
+        Weighted density per ``hp.density_words_basis`` effective words.
+    """
+    if word_count_value <= 0:
+        return 0.0
+
+    effective_word_count = max(word_count_value, hp.density_min_word_count)
+    return weighted_sum / (effective_word_count / hp.density_words_basis)
 
 
 def band_for_score(score: int, hp: Hyperparameters) -> str:

--- a/src/slop_guard/server.py
+++ b/src/slop_guard/server.py
@@ -14,6 +14,7 @@ from .analysis import (
     Hyperparameters,
     band_for_score,
     compute_weighted_sum,
+    density_from_weighted_sum,
     deduplicate_advice,
     initial_counts,
     serialize_violations,
@@ -54,10 +55,10 @@ def _analyze(
         state.counts,
         hyperparameters,
     )
-    density = (
-        weighted_sum / (document.word_count / hyperparameters.density_words_basis)
-        if document.word_count > 0
-        else 0.0
+    density = density_from_weighted_sum(
+        weighted_sum,
+        document.word_count,
+        hyperparameters,
     )
     score = score_from_density(density, hyperparameters)
     band = band_for_score(score, hyperparameters)

--- a/tests/test_analysis_pipeline.py
+++ b/tests/test_analysis_pipeline.py
@@ -1,8 +1,35 @@
 """Integration tests for rule-pipeline based analysis output."""
 
 
-from slop_guard.analysis import AnalysisDocument, HYPERPARAMETERS, word_count
+from slop_guard.analysis import (
+    AnalysisDocument,
+    HYPERPARAMETERS,
+    density_from_weighted_sum,
+    word_count,
+)
 from slop_guard.server import _analyze
+
+
+def _single_slop_word_text(sentence_lengths: tuple[int, ...]) -> str:
+    """Build synthetic prose with one slop word and otherwise neutral tokens.
+
+    Args:
+        sentence_lengths: Sentence word counts that sum to the full document size.
+
+    Returns:
+        Synthetic prose split into the requested sentence lengths.
+    """
+    total_words = sum(sentence_lengths)
+    tokens = [f"token{index}" for index in range(total_words)]
+    tokens[5] = "crucial"
+
+    sentences: list[str] = []
+    cursor = 0
+    for length in sentence_lengths:
+        sentence_tokens = tokens[cursor : cursor + length]
+        sentences.append(" ".join(sentence_tokens) + ".")
+        cursor += length
+    return " ".join(sentences)
 
 
 def test_analyze_runs_instantiated_rule_pipeline() -> None:
@@ -98,6 +125,34 @@ def test_analyze_short_text_exposes_full_count_schema() -> None:
     }.issubset(result["counts"])
     assert result["counts"]["closing_aphorism"] == 0
     assert result["counts"]["paragraph_cv"] == 0
+
+
+def test_density_normalization_uses_min_word_floor() -> None:
+    """Short documents should use the minimum effective word count."""
+    short_density = density_from_weighted_sum(2.0, 32, HYPERPARAMETERS)
+    long_density = density_from_weighted_sum(2.0, 244, HYPERPARAMETERS)
+
+    assert short_density == 10.0
+    assert round(long_density, 2) == 8.2
+
+
+def test_analyze_same_single_violation_stays_in_same_band_across_lengths() -> None:
+    """One slop word should not collapse a short document into saturation."""
+    short_text = _single_slop_word_text((14, 18))
+    long_text = _single_slop_word_text((60, 58, 62, 64))
+
+    short_result = _analyze(short_text, HYPERPARAMETERS)
+    long_result = _analyze(long_text, HYPERPARAMETERS)
+
+    assert len(short_result["violations"]) == 1
+    assert len(long_result["violations"]) == 1
+    assert short_result["counts"]["slop_words"] == 1
+    assert long_result["counts"]["slop_words"] == 1
+    assert short_result["weighted_sum"] == 2.0
+    assert long_result["weighted_sum"] == 2.0
+    assert short_result["band"] == "light"
+    assert long_result["band"] == "light"
+    assert abs(short_result["score"] - long_result["score"]) <= 6
 
 
 def test_structural_subcategory_violations_use_specific_count_keys() -> None:


### PR DESCRIPTION
## Description

This change moves score-density normalization into a shared helper and floors the effective word count at 200 before dividing the weighted penalty sum. Short documents still get penalized, but a single hit no longer explodes into a saturated score just because the input is brief. The patch also updates the README and adds regression coverage for both the helper and the short-vs-long reproduction from issue #49.

## Why?

Issue #49 showed that the previous formula, `weighted_sum / (word_count / 1000)`, let absolute length dominate the score. Two documents with one `slop_word` hit could land 60+ points apart when the only real difference was padding. The minimum denominator floor keeps the scoring curve stable for paragraphs, commit messages, and other short inputs that should remain comparable to longer prose with the same violation rate.

## Usage / Demonstration

```python
short_result = _analyze(_single_slop_word_text((14, 18)), HYPERPARAMETERS)
long_result = _analyze(_single_slop_word_text((60, 58, 62, 64)), HYPERPARAMETERS)

assert short_result["weighted_sum"] == 2.0
assert long_result["weighted_sum"] == 2.0
assert short_result["band"] == "light"
assert long_result["band"] == "light"
```

```python
assert density_from_weighted_sum(2.0, 32, HYPERPARAMETERS) == 10.0
assert round(density_from_weighted_sum(2.0, 244, HYPERPARAMETERS), 2) == 8.2
```

## Verification

- `uv run pytest`
- `slop_guard.check_slop_file` on `README.md` returned `100 / clean`
- `slop_guard.check_slop` on this PR body returned `100 / clean`

## Issues

- Closes #49
