### PR TITLE
Handle long inline CLI text safely

### DIFF
--- a/src/slop_guard/cli.py
+++ b/src/slop_guard/cli.py
@@ -218,6 +218,23 @@ def _is_inline_text_argument(value: str) -> bool:
     return any(ch.isspace() for ch in value)
 
 
+def _path_points_to_existing_file(path: Path) -> bool:
+    """Return whether ``path`` exists as a regular file.
+
+    Args:
+        path: Candidate filesystem path supplied on the CLI.
+
+    Returns:
+        ``True`` when the path can be stat'ed and resolves to a regular file.
+        ``False`` when the path does not exist or the OS rejects the stat call,
+        such as ``ENAMETOOLONG`` for long inline prose strings.
+    """
+    try:
+        return path.is_file()
+    except OSError:
+        return False
+
+
 def _resolve_inputs(args: argparse.Namespace) -> list[InputTarget]:
     """Resolve positional args into typed input targets."""
     inputs: list[InputTarget] = []
@@ -226,7 +243,7 @@ def _resolve_inputs(args: argparse.Namespace) -> list[InputTarget]:
             inputs.append(InputTarget(kind="stdin", value=raw, display_label="<stdin>"))
             continue
         candidate_path = Path(raw)
-        if candidate_path.is_file():
+        if _path_points_to_existing_file(candidate_path):
             inputs.append(
                 InputTarget(
                     kind="file",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import io
 import json
 from pathlib import Path
@@ -63,6 +64,41 @@ def test_accepts_inline_text_input(capsys: pytest.CaptureFixture[str]) -> None:
     assert captured.err == ""
     assert captured.out.startswith("<text:1>: ")
     assert "/100 [" in captured.out
+
+
+def test_long_inline_text_falls_back_from_path_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inline prose should stay inline when ``Path.is_file()`` raises ``OSError``."""
+    long_text = "This is a long inline prose sample. " * 16
+
+    def fake_is_file(self: Path) -> bool:
+        if self == Path(long_text):
+            raise OSError(63, "File name too long")
+        return False
+
+    monkeypatch.setattr(Path, "is_file", fake_is_file)
+
+    targets = cli._resolve_inputs(argparse.Namespace(inputs=[long_text]))
+
+    assert targets == [
+        cli.InputTarget(kind="text", value=long_text, display_label="<text:1>")
+    ]
+
+
+def test_existing_file_with_spaces_still_resolves_as_file(write_text_file) -> None:
+    """Existing file paths should outrank inline-text detection."""
+    spaced_file = write_text_file("notes with spaces.md", "alpha")
+
+    targets = cli._resolve_inputs(argparse.Namespace(inputs=[str(spaced_file)]))
+
+    assert targets == [
+        cli.InputTarget(
+            kind="file",
+            value=spaced_file,
+            display_label=str(spaced_file),
+        )
+    ]
 
 
 def test_score_only_mode_prints_score_only(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Description

This PR makes `sg` handle long inline prose without crashing during input resolution. It adds a small helper around `Path.is_file()` so OS-level `OSError` values such as `ENAMETOOLONG` fall back to inline-text handling, and it adds regression coverage for that case plus existing file paths that contain spaces.

## Why?

Issue #64 reports that the documented inline-text mode breaks on normal paragraph-length input because the CLI probes the raw string as a filesystem path before classifying it as prose. On macOS, that stat can fail once the argument exceeds `NAME_MAX`, which turns ordinary inline usage into a hard crash instead of a score.

## Usage / Demonstration

```bash
LONG_TEXT="$(printf 'This inline sample sentence stays concrete. %.0s' {1..16})"
uv run sg --json "$LONG_TEXT"
```

The command now returns JSON analysis for the inline text instead of raising `OSError: [Errno 63] File name too long`.

## Verification

- `uv run pytest tests/test_cli.py`
- `uv run pytest`
- `uv run sg README.md`
- `LONG_TEXT="$(printf 'This inline sample sentence stays concrete. %.0s' {1..16})" && uv run sg --json "$LONG_TEXT"`

## Issues

- Closes #64
