### PR TITLE
Add triadic rewrite advice

### DIFF
--- a/src/slop_guard/rules/paragraph_level/structural_pattern_rule.py
+++ b/src/slop_guard/rules/paragraph_level/structural_pattern_rule.py
@@ -36,6 +36,21 @@ _BOLD_HEADER_RE = re.compile(r"\*\*[^*]+[.:]\*\*\s+\S")
 _TRIADIC_RE = re.compile(r"\w+, \w+, and \w+", re.IGNORECASE)
 
 
+def _triadic_advice(snippet: str) -> str:
+    """Return rewrite guidance for a matched triadic list.
+
+    Args:
+        snippet: The matched ``X, Y, and Z`` fragment.
+
+    Returns:
+        A concrete rewrite direction for the matched triadic cadence.
+    """
+    return (
+        f"Rewrite '{snippet}' as prose or restructure the list so the sentence "
+        "does not hinge on a three-item cadence."
+    )
+
+
 @dataclass
 class StructuralPatternRuleConfig(RuleConfig):
     """Config for listicle-like structural pattern thresholds."""
@@ -131,6 +146,7 @@ class StructuralPatternRule(Rule[StructuralPatternRuleConfig]):
         triadic_matches = list(_TRIADIC_RE.finditer(document.text))
         triadic_count = len(triadic_matches)
         for match in triadic_matches[: self.config.triadic_record_cap]:
+            snippet = match.group(0)
             violations.append(
                 Violation(
                     rule=self.name,
@@ -144,6 +160,7 @@ class StructuralPatternRule(Rule[StructuralPatternRuleConfig]):
                     penalty=self.config.triadic_penalty,
                 )
             )
+            advice.append(_triadic_advice(snippet))
             count += 1
 
         if triadic_count >= self.config.triadic_advice_min:

--- a/tests/test_advice_updates.py
+++ b/tests/test_advice_updates.py
@@ -93,6 +93,42 @@ def test_rhythm_advice_reports_threshold_and_sentence_range() -> None:
     ]
 
 
+def test_single_triadic_structural_violation_has_actionable_advice() -> None:
+    """A single triadic structural hit should still tell the user what to change."""
+    text = (
+        "We support three output formats: JSON, YAML, and TOML. "
+        "Each one is fully validated before writing. "
+        "The default format is JSON because it has the broadest tool support."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert any(
+        violation["rule"] == "structural" and violation["match"] == "triadic"
+        for violation in result["violations"]
+    )
+    assert result["advice"] == [
+        "Rewrite 'JSON, YAML, and TOML' as prose or restructure the list so "
+        "the sentence does not hinge on a three-item cadence."
+    ]
+
+
+def test_repeated_triadic_structures_keep_aggregate_cadence_advice() -> None:
+    """Repeated triads should still emit the aggregate cadence warning."""
+    text = (
+        "The platform is reliable, scalable, and maintainable in production. "
+        "The rollout stayed measured, observable, and reversible overnight. "
+        "The handoff remained clear, direct, and documented for operators."
+    )
+
+    result = _analyze(text, HYPERPARAMETERS)
+
+    assert (
+        "3 triadic structures ('X, Y, and Z') — vary your list cadence."
+        in result["advice"]
+    )
+
+
 def test_overlapping_phrase_rules_share_one_canonical_edit_message() -> None:
     """Overlapping phrase and tone rules should deduplicate shared guidance."""
     text = (


### PR DESCRIPTION
## Description

This change adds explicit rewrite advice for each recorded `triadic` match in `StructuralPatternRule`. The existing aggregate cadence warning stays in place for repeated matches, and the regression coverage now checks both the single-hit and repeated-hit paths through `_analyze`.

## Why?

Issue #67 showed that the rule could penalize a three-item list while returning an empty `advice` array. That left users with a score change but no rewrite direction.

## Usage / Demonstration

```bash
uv run sg --json "We support three output formats: JSON, YAML, and TOML. Each one is fully validated before writing. The default format is JSON because it has the broadest tool support."
```

The response now includes an `advice` entry for the matched list, rather than returning `[]`.

Repeated matches still add the aggregate cadence warning once the configured threshold is met.

## Verification

- `uv run pytest tests/test_advice_updates.py -q`
- `uv run pytest tests/test_advice_updates.py tests/test_analysis_pipeline.py -q`
- `uv run pytest -q`
- Ran the issue #67 `uv run sg --json ...` reproduction command and confirmed that the response now includes rewrite advice.

## Issues

Closes #67