### PR TITLE
Handle empty CLI inputs explicitly

### DIFF
--- a/src/slop_guard/cli.py
+++ b/src/slop_guard/cli.py
@@ -75,6 +75,10 @@ class InputTarget:
     display_label: str
 
 
+class InputResolutionError(ValueError):
+    """Raised when a CLI positional input cannot be resolved."""
+
+
 def _format_score_line(
     label: str,
     result: dict,
@@ -219,9 +223,17 @@ def _is_inline_text_argument(value: str) -> bool:
 
 
 def _resolve_inputs(args: argparse.Namespace) -> list[InputTarget]:
-    """Resolve positional args into typed input targets."""
+    """Resolve positional args into typed input targets.
+
+    Raises:
+        InputResolutionError: If any positional input is an empty string.
+    """
     inputs: list[InputTarget] = []
     for index, raw in enumerate(args.inputs, start=1):
+        if raw == "":
+            raise InputResolutionError(
+                f"input {index} is empty; pass non-empty inline text, a file path, or '-' for stdin"
+            )
         if raw == "-":
             inputs.append(InputTarget(kind="stdin", value=raw, display_label="<stdin>"))
             continue
@@ -286,7 +298,11 @@ def cli_main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    inputs = _resolve_inputs(args)
+    try:
+        inputs = _resolve_inputs(args)
+    except InputResolutionError as exc:
+        print(f"sg: {exc}", file=sys.stderr)
+        return EXIT_ERROR
 
     results: list[SourceAnalysisPayload] = []
     threshold_failed = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,38 @@ def test_requires_at_least_one_input(capsys: pytest.CaptureFixture[str]) -> None
     assert "the following arguments are required: INPUT" in capsys.readouterr().err
 
 
+def test_rejects_empty_string_input(
+    capsys: pytest.CaptureFixture[str],
+    cli_pipeline,
+) -> None:
+    """An empty quoted input should fail with a direct validation error."""
+    exit_code = cli.cli_main([""])
+    captured = capsys.readouterr()
+
+    assert exit_code == cli.EXIT_ERROR
+    assert captured.out == ""
+    assert "sg: input 1 is empty" in captured.err
+    assert "No such file" not in captured.err
+    assert cli_pipeline.loaded_paths == []
+
+
+def test_rejects_empty_string_input_after_valid_argument(
+    capsys: pytest.CaptureFixture[str],
+    cli_pipeline,
+    write_text_file,
+) -> None:
+    """Any empty positional argument should fail before analysis begins."""
+    sample = write_text_file("sample.md", "alpha")
+
+    exit_code = cli.cli_main([str(sample), ""])
+    captured = capsys.readouterr()
+
+    assert exit_code == cli.EXIT_ERROR
+    assert captured.out == ""
+    assert "sg: input 2 is empty" in captured.err
+    assert cli_pipeline.loaded_paths == []
+
+
 def test_version_flag_prints_package_version(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -87,6 +119,20 @@ def test_json_mode_includes_source_field(
     assert captured.err == ""
     assert payload["source"] == "This is some test text"
     assert payload["score"] == 100
+
+
+def test_json_mode_rejects_empty_string_input(
+    capsys: pytest.CaptureFixture[str],
+    cli_pipeline,
+) -> None:
+    """JSON mode should still reject an empty quoted input."""
+    exit_code = cli.cli_main(["--json", ""])
+    captured = capsys.readouterr()
+
+    assert exit_code == cli.EXIT_ERROR
+    assert captured.out == ""
+    assert "sg: input 1 is empty" in captured.err
+    assert cli_pipeline.loaded_paths == []
 
 
 def test_json_mode_uses_stdin_text_as_source(


### PR DESCRIPTION
## Description

This PR teaches `sg` to reject empty positional arguments before they are resolved as filesystem paths. An empty quoted string now exits with code 2 and prints a dedicated empty-input error instead of the misleading `sg: .: No such file` message. The change is limited to the CLI resolver and targeted regression coverage.

## Why?

Issue #69 reports that `Path("")` normalizes to the current directory, so the CLI turns `""` into `.` and emits a file-not-found error that does not explain the real problem. Failing at argument resolution makes the error deterministic, prevents partial processing when one positional argument is empty, and gives users a direct correction path.

## Usage / Demonstration

```bash
uv run sg ""
# stderr: sg: input 1 is empty; pass non-empty inline text, a file path, or '-' for stdin
# exit: 2
```

## Verification

Ran `uv run pytest tests/test_cli.py -q` and confirmed `12 passed`. Also ran `uv run sg ""` to verify the direct reproduction now fails with the new empty-input message instead of `sg: .: No such file`.

## Issues

Closes #69
