### PR TITLE
Fix sg-fit negative dataset positional parsing

### DIFF
--- a/src/slop_guard/fit_cli.py
+++ b/src/slop_guard/fit_cli.py
@@ -159,6 +159,20 @@ def _flatten_inputs(groups: list[list[str]] | None) -> list[str]:
     return [item for group in groups for item in group]
 
 
+def _matches_option_token(token: str, option: str) -> bool:
+    """Return whether ``token`` encodes ``option``.
+
+    Args:
+        token: One CLI token.
+        option: The long option name to compare against.
+
+    Returns:
+        ``True`` when ``token`` is either the exact option or the ``--name=value``
+        inline form accepted by ``argparse``.
+    """
+    return token == option or token.startswith(f"{option}=")
+
+
 def _normalize_negative_dataset_argv(argv: list[str] | None) -> list[str]:
     """Insert ``--`` when needed to preserve positional inputs.
 
@@ -173,10 +187,14 @@ def _normalize_negative_dataset_argv(argv: list[str] | None) -> list[str]:
         training inputs attached to ``inputs``.
     """
     raw_argv = list(sys.argv[1:] if argv is None else argv)
-    if "--" in raw_argv or _NEGATIVE_DATASET_OPTION not in raw_argv:
+    if "--" in raw_argv or not any(
+        _matches_option_token(token, _NEGATIVE_DATASET_OPTION) for token in raw_argv
+    ):
         return raw_argv
 
-    required_inputs = 1 if "--output" in raw_argv else 2
+    required_inputs = (
+        1 if any(_matches_option_token(token, "--output") for token in raw_argv) else 2
+    )
     outside_positionals = 0
     final_group_start: int | None = None
     final_group_size = 0

--- a/tests/test_fit_cli.py
+++ b/tests/test_fit_cli.py
@@ -166,6 +166,33 @@ def test_fit_main_allows_negative_dataset_before_positional_input(
     assert fit_pipeline.output_paths == [output]
 
 
+def test_fit_main_allows_negative_dataset_before_positional_input_with_inline_output(
+    write_text_file,
+    fit_pipeline,
+) -> None:
+    """Inline ``--output=...`` should still preserve the train input."""
+    target = write_text_file("target.txt", "target body")
+    negative = write_text_file("negative.txt", "negative body")
+    output = write_text_file("rules.fitted.jsonl", "")
+
+    exit_code = fit_cli.fit_main(
+        [
+            f"--output={output}",
+            "--negative-dataset",
+            str(negative),
+            str(target),
+        ]
+    )
+
+    assert exit_code == fit_cli.EXIT_OK
+    assert fit_pipeline.fit_calls[0].samples == (
+        "target body",
+        "negative body",
+    )
+    assert fit_pipeline.fit_calls[0].labels == (1, 0)
+    assert fit_pipeline.output_paths == [output]
+
+
 def test_fit_main_allows_negative_dataset_before_legacy_positionals(
     write_text_file,
     fit_pipeline,


### PR DESCRIPTION
## Description

This updates `sg-fit` so a trailing training input is preserved when the final `--negative-dataset` group appears before positional inputs. The CLI now normalizes the argv sequence by inserting an internal `--` separator only when the final negative-dataset argument list would otherwise consume the required positional suffix, and that normalization also recognizes argparse's inline `--output=...` form. Existing multi-value `--negative-dataset` usage and repeated-flag behavior stay intact, and the change is covered by focused regressions for both `--output` mode and the legacy `TARGET_CORPUS OUTPUT` shorthand.

## Why?

Issue #70 reports a real argparse limitation: `--negative-dataset` used `nargs='+'`, so when users wrote flags first, the option greedily consumed the positional input and `sg-fit` failed with "the following arguments are required: INPUT". That ordering is natural CLI usage, so the command needed to accept it instead of depending on argument order knowledge.

## Usage / Demonstration

```bash
# This now works.
uv run sg-fit --output output.jsonl --negative-dataset bad.jsonl good.jsonl

# The inline output form is handled too.
uv run sg-fit --output=output.jsonl --negative-dataset bad.jsonl good.jsonl

# The legacy shorthand also works with the negative dataset first.
uv run sg-fit --negative-dataset bad.jsonl good.jsonl output.jsonl
```

## Verification

- `uv run pytest tests/test_fit_cli.py`
- `uv run sg-fit --output output.jsonl --negative-dataset bad.jsonl good.jsonl`
- `uv run sg-fit --output=output.jsonl --negative-dataset bad.jsonl good.jsonl`

## Issues

- Closes #70
