### PR TITLE
Extract markdown masking into a shared module

### DIFF
--- a/src/slop_guard/analysis.py
+++ b/src/slop_guard/analysis.py
@@ -8,9 +8,10 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Literal, TypeAlias, TypedDict
 
+from .markdown import MarkdownCodeView
+
 Counts: TypeAlias = dict[str, int]
 BandLabel: TypeAlias = Literal["clean", "light", "moderate", "heavy", "saturated"]
-Span: TypeAlias = tuple[int, int]
 
 
 class ViolationPayload(TypedDict):
@@ -153,9 +154,7 @@ class Violation:
 _SENTENCE_SPLIT_RE = re.compile(r"[.!?][\"'\u201D\u2019)\]]*(?:\s|$)")
 _BULLET_LINE_RE = re.compile(r"^\s*[-*]\s|^\s*\d+[.)]\s")
 _BOLD_TERM_BULLET_LINE_RE = re.compile(r"^\s*[-*]\s+\*\*|^\s*\d+[.)]\s+\*\*")
-_FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
 _MARKDOWN_TABLE_DELIMITER_CELL_RE = re.compile(r"^\s*:?-{3,}:?\s*$")
-_NON_NEWLINE_RE = re.compile(r"[^\n]")
 _WORD_TOKEN_RE = re.compile(r"\w+")
 _EDGE_WORD_STRIP_RE = re.compile(r"^[^\w]+|[^\w]+$")
 
@@ -212,128 +211,6 @@ def _replace_markdown_tables_with_sentence_breaks(text: str) -> str:
     return "\n".join(normalized_lines)
 
 
-def _line_start_index(text: str, index: int) -> int:
-    """Return the start index of the line containing ``index``."""
-    return text.rfind("\n", 0, index) + 1
-
-
-def _backtick_run_length(text: str, index: int) -> int:
-    """Return the number of consecutive backticks starting at ``index``."""
-    end = index
-    while end < len(text) and text[end] == "`":
-        end += 1
-    return end - index
-
-
-def _looks_like_fenced_code_opener(text: str, index: int, backtick_count: int) -> bool:
-    """Return whether a backtick run can open a Markdown fenced code block."""
-    if backtick_count < 3:
-        return False
-    line_start = _line_start_index(text, index)
-    indent = text[line_start:index]
-    return len(indent) <= 3 and indent.strip() == ""
-
-
-def _find_fenced_code_block_end(
-    text: str,
-    opener_start: int,
-    backtick_count: int,
-) -> int:
-    """Return the exclusive end index of a fenced code block."""
-    cursor = text.find("\n", opener_start)
-    if cursor < 0:
-        return len(text)
-    cursor += 1
-
-    while cursor < len(text):
-        line_end = text.find("\n", cursor)
-        if line_end < 0:
-            line_end = len(text)
-        line = text[cursor:line_end]
-        stripped = line.lstrip(" ")
-        indent = len(line) - len(stripped)
-        fence_width = _backtick_run_length(stripped, 0) if stripped else 0
-
-        if (
-            indent <= 3
-            and fence_width >= backtick_count
-            and stripped.startswith("`" * backtick_count)
-            and stripped[fence_width:].strip() == ""
-        ):
-            return line_end if line_end == len(text) else line_end + 1
-
-        cursor = line_end + 1
-
-    return len(text)
-
-
-def _find_inline_code_span_end(
-    text: str,
-    opener_start: int,
-    backtick_count: int,
-) -> int | None:
-    """Return the exclusive end index of an inline backtick code span."""
-    cursor = opener_start + backtick_count
-    line_end = text.find("\n", cursor)
-    limit = len(text) if line_end < 0 else line_end
-
-    while cursor < limit:
-        if text[cursor] != "`":
-            cursor += 1
-            continue
-
-        candidate_width = _backtick_run_length(text, cursor)
-        if candidate_width == backtick_count:
-            return cursor + backtick_count
-        cursor += candidate_width
-
-    return None
-
-
-def _markdown_code_spans(text: str) -> tuple[Span, ...]:
-    """Return fenced and inline Markdown code spans in ``text``."""
-    spans: list[Span] = []
-    cursor = 0
-
-    while cursor < len(text):
-        if text[cursor] != "`":
-            cursor += 1
-            continue
-
-        backtick_count = _backtick_run_length(text, cursor)
-        if _looks_like_fenced_code_opener(text, cursor, backtick_count):
-            block_end = _find_fenced_code_block_end(text, cursor, backtick_count)
-            spans.append((cursor, block_end))
-            cursor = block_end
-            continue
-
-        inline_end = _find_inline_code_span_end(text, cursor, backtick_count)
-        if inline_end is not None:
-            spans.append((cursor, inline_end))
-            cursor = inline_end
-            continue
-
-        cursor += backtick_count
-
-    return tuple(spans)
-
-
-def _mask_markdown_code(text: str) -> str:
-    """Return ``text`` with Markdown code spans replaced by whitespace."""
-    spans = _markdown_code_spans(text)
-    if not spans:
-        return text
-
-    pieces: list[str] = []
-    cursor = 0
-    for start, end in spans:
-        pieces.append(text[cursor:start])
-        pieces.append(_NON_NEWLINE_RE.sub(" ", text[start:end]))
-        cursor = end
-    pieces.append(text[cursor:])
-    return "".join(pieces)
-
-
 @dataclass(frozen=True)
 class AnalysisDocument:
     """Precomputed text views consumed by rules in forward passes."""
@@ -342,15 +219,18 @@ class AnalysisDocument:
     lines: tuple[str, ...]
     sentences: tuple[str, ...]
     word_count: int
+    markdown_code_view: MarkdownCodeView
 
     @classmethod
     def from_text(cls, text: str) -> "AnalysisDocument":
         """Build a document with line/sentence/word projections."""
+        markdown_code_view = MarkdownCodeView.from_text(text)
         return cls(
             text=text,
             lines=tuple(text.split("\n")),
             sentences=_split_sentences(text),
-            word_count=word_count(_mask_markdown_code(text)),
+            word_count=word_count(markdown_code_view.masked_text),
+            markdown_code_view=markdown_code_view,
         )
 
     @cached_property
@@ -361,8 +241,9 @@ class AnalysisDocument:
     @cached_property
     def sentence_analysis_text(self) -> str:
         """Return sentence-analysis text with Markdown blocks replaced."""
-        text_without_code_blocks = _FENCED_CODE_BLOCK_RE.sub("\n.\n", self.text)
-        return _replace_markdown_tables_with_sentence_breaks(text_without_code_blocks)
+        return _replace_markdown_tables_with_sentence_breaks(
+            self.markdown_code_view.fenced_text_for_sentence_breaks
+        )
 
     @cached_property
     def sentence_analysis_sentences(self) -> tuple[str, ...]:
@@ -446,7 +327,7 @@ class AnalysisDocument:
     @cached_property
     def text_without_code_blocks(self) -> str:
         """Return cached text with fenced code blocks removed."""
-        return _FENCED_CODE_BLOCK_RE.sub("", self.text)
+        return self.markdown_code_view.text_without_fenced_code
 
     @cached_property
     def word_count_without_code_blocks(self) -> int:
@@ -456,7 +337,7 @@ class AnalysisDocument:
     @cached_property
     def text_with_markdown_code_masked(self) -> str:
         """Return cached text with Markdown code replaced by whitespace."""
-        return _mask_markdown_code(self.text)
+        return self.markdown_code_view.masked_text
 
     @cached_property
     def lower_text_with_markdown_code_masked(self) -> str:

--- a/src/slop_guard/markdown.py
+++ b/src/slop_guard/markdown.py
@@ -1,0 +1,254 @@
+"""Reusable Markdown code-span detection and derived text views.
+
+This module centralizes Markdown code handling so analysis paths can share one
+scan of the source text and derive consistent masked or stripped views.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TypeAlias
+
+Span: TypeAlias = tuple[int, int]
+
+_NON_NEWLINE_RE = re.compile(r"[^\n]")
+
+
+def _line_start_index(text: str, index: int) -> int:
+    """Return the start index of the line containing ``index``.
+
+    Args:
+        text: Full source text.
+        index: Character index inside ``text``.
+
+    Returns:
+        The zero-based index of the start of the containing line.
+    """
+    return text.rfind("\n", 0, index) + 1
+
+
+def _backtick_run_length(text: str, index: int) -> int:
+    """Return the number of consecutive backticks starting at ``index``.
+
+    Args:
+        text: Full source text.
+        index: Zero-based character offset.
+
+    Returns:
+        The width of the backtick run that begins at ``index``.
+    """
+    end = index
+    while end < len(text) and text[end] == "`":
+        end += 1
+    return end - index
+
+
+def _looks_like_fenced_code_opener(text: str, index: int, backtick_count: int) -> bool:
+    """Return whether a backtick run can open a fenced code block.
+
+    Args:
+        text: Full source text.
+        index: Zero-based character offset of the backtick run.
+        backtick_count: Width of the backtick run.
+
+    Returns:
+        ``True`` when the run looks like a Markdown fence opener.
+    """
+    if backtick_count < 3:
+        return False
+    line_start = _line_start_index(text, index)
+    indent = text[line_start:index]
+    return len(indent) <= 3 and indent.strip() == ""
+
+
+def _find_fenced_code_block_end(
+    text: str,
+    opener_start: int,
+    backtick_count: int,
+) -> int:
+    """Return the exclusive end index of a fenced code block.
+
+    Args:
+        text: Full source text.
+        opener_start: Offset of the opening fence.
+        backtick_count: Width of the opening fence.
+
+    Returns:
+        The exclusive end offset of the fenced block. If no closer exists, the
+        end of the document is returned.
+    """
+    cursor = text.find("\n", opener_start)
+    if cursor < 0:
+        return len(text)
+    cursor += 1
+
+    while cursor < len(text):
+        line_end = text.find("\n", cursor)
+        if line_end < 0:
+            line_end = len(text)
+        line = text[cursor:line_end]
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        fence_width = _backtick_run_length(stripped, 0) if stripped else 0
+
+        if (
+            indent <= 3
+            and fence_width >= backtick_count
+            and stripped.startswith("`" * backtick_count)
+            and stripped[fence_width:].strip() == ""
+        ):
+            return line_end if line_end == len(text) else line_end + 1
+
+        cursor = line_end + 1
+
+    return len(text)
+
+
+def _find_inline_code_span_end(
+    text: str,
+    opener_start: int,
+    backtick_count: int,
+) -> int | None:
+    """Return the exclusive end index of an inline code span.
+
+    Args:
+        text: Full source text.
+        opener_start: Offset of the opening backtick run.
+        backtick_count: Width of the opening run.
+
+    Returns:
+        The exclusive end offset of the matching inline span, or ``None`` when
+        a closer does not exist on the same line.
+    """
+    cursor = opener_start + backtick_count
+    line_end = text.find("\n", cursor)
+    limit = len(text) if line_end < 0 else line_end
+
+    while cursor < limit:
+        if text[cursor] != "`":
+            cursor += 1
+            continue
+
+        candidate_width = _backtick_run_length(text, cursor)
+        if candidate_width == backtick_count:
+            return cursor + backtick_count
+        cursor += candidate_width
+
+    return None
+
+
+def _replace_spans(text: str, spans: tuple[Span, ...], replacement: str) -> str:
+    """Replace each span in ``text`` with the same ``replacement`` string.
+
+    Args:
+        text: Full source text.
+        spans: Sorted, non-overlapping spans to replace.
+        replacement: Replacement text for each span.
+
+    Returns:
+        The transformed text.
+    """
+    if not spans:
+        return text
+
+    pieces: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        pieces.append(text[cursor:start])
+        pieces.append(replacement)
+        cursor = end
+    pieces.append(text[cursor:])
+    return "".join(pieces)
+
+
+def _mask_spans_preserving_newlines(text: str, spans: tuple[Span, ...]) -> str:
+    """Replace span contents with whitespace while preserving newlines.
+
+    Args:
+        text: Full source text.
+        spans: Sorted, non-overlapping spans to mask.
+
+    Returns:
+        A string with the same length as ``text`` where masked characters are
+        replaced by spaces, except newlines which are preserved.
+    """
+    if not spans:
+        return text
+
+    pieces: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        pieces.append(text[cursor:start])
+        pieces.append(_NON_NEWLINE_RE.sub(" ", text[start:end]))
+        cursor = end
+    pieces.append(text[cursor:])
+    return "".join(pieces)
+
+
+@dataclass(frozen=True)
+class MarkdownCodeView:
+    """Precomputed Markdown code-span projections for one text input.
+
+    Attributes:
+        all_spans: Fenced and inline code spans.
+        fenced_spans: Fenced code spans only.
+        masked_text: Full text with all code spans replaced by whitespace.
+        text_without_fenced_code: Full text with fenced blocks removed.
+        fenced_text_for_sentence_breaks: Full text with fenced blocks replaced
+            by ``\\n.\\n`` to preserve sentence boundaries.
+    """
+
+    all_spans: tuple[Span, ...]
+    fenced_spans: tuple[Span, ...]
+    masked_text: str
+    text_without_fenced_code: str
+    fenced_text_for_sentence_breaks: str
+
+    @classmethod
+    def from_text(cls, text: str) -> MarkdownCodeView:
+        """Build Markdown code-span views for ``text``.
+
+        Args:
+            text: Full source text.
+
+        Returns:
+            A reusable bundle of Markdown code projections.
+        """
+        all_spans: list[Span] = []
+        fenced_spans: list[Span] = []
+        cursor = 0
+
+        while cursor < len(text):
+            if text[cursor] != "`":
+                cursor += 1
+                continue
+
+            backtick_count = _backtick_run_length(text, cursor)
+            if _looks_like_fenced_code_opener(text, cursor, backtick_count):
+                block_end = _find_fenced_code_block_end(text, cursor, backtick_count)
+                span = (cursor, block_end)
+                fenced_spans.append(span)
+                all_spans.append(span)
+                cursor = block_end
+                continue
+
+            inline_end = _find_inline_code_span_end(text, cursor, backtick_count)
+            if inline_end is not None:
+                all_spans.append((cursor, inline_end))
+                cursor = inline_end
+                continue
+
+            cursor += backtick_count
+
+        all_spans_tuple = tuple(all_spans)
+        fenced_spans_tuple = tuple(fenced_spans)
+        return cls(
+            all_spans=all_spans_tuple,
+            fenced_spans=fenced_spans_tuple,
+            masked_text=_mask_spans_preserving_newlines(text, all_spans_tuple),
+            text_without_fenced_code=_replace_spans(text, fenced_spans_tuple, ""),
+            fenced_text_for_sentence_breaks=_replace_spans(
+                text, fenced_spans_tuple, "\n.\n"
+            ),
+        )

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,25 @@
+"""Tests for reusable Markdown code-span views."""
+
+from slop_guard.markdown import MarkdownCodeView
+
+
+def test_markdown_code_view_tracks_fenced_and_inline_code_separately() -> None:
+    """The shared view should expose both all-code and fenced-only projections."""
+    text = (
+        "Intro `robust journey` example.\n\n"
+        "```python\n"
+        "navigate_landscape()\n"
+        "```\n\n"
+        "Closing line."
+    )
+
+    view = MarkdownCodeView.from_text(text)
+
+    assert len(view.all_spans) == 2
+    assert len(view.fenced_spans) == 1
+    assert len(view.masked_text) == len(text)
+    assert "robust journey" not in view.masked_text
+    assert "navigate_landscape" not in view.masked_text
+    assert "`robust journey`" in view.text_without_fenced_code
+    assert "navigate_landscape" not in view.text_without_fenced_code
+    assert "\n.\n" in view.fenced_text_for_sentence_breaks


### PR DESCRIPTION
## Description

This PR moves Markdown code-span detection and the derived text projections into a new `slop_guard.markdown` module. `AnalysisDocument.from_text()` now builds one `MarkdownCodeView` and reuses it for masked text, fenced-block removal, and the fenced sentence-analysis projection, so the logic from #87 lives in one place.

## Why?

PR #87 fixed the behavior, but the implementation still split Markdown code handling across `analysis.py` helpers and rule-facing cached properties. That made the fenced-only and full-code paths harder to compare and left the document rebuilding overlapping transforms in separate places. This follow-up keeps the public `AnalysisDocument` API stable while giving the repo one shared implementation.

## Usage / Demonstration

```bash
uv run pytest tests/test_markdown.py tests/test_analysis_pipeline.py tests/test_rule_framework.py tests/test_extreme_sentence_rule.py tests/test_server_tools.py
uv run sg --json $'Here is clean prose.\\n\\n```python\\ndef run_query(client):\\n    return client.fetch()\\n```\\n\\nThe rollout note matters to operators today.'\n```\n\nThe first command exercises the shared Markdown module directly and through the existing analysis consumers. The second command still ignores the fenced and inline code spans and reports only the prose text.\n\n## Verification\n\n- `uv run pytest tests/test_markdown.py tests/test_analysis_pipeline.py tests/test_rule_framework.py tests/test_extreme_sentence_rule.py tests/test_server_tools.py`\n- `uv run pytest`\n- `uv run sg --json $'Here is clean prose.\\n\\n```python\\ndef run_query(client):\\n    return client.fetch()\\n```\\n\\nThe rollout note matters to operators today.'`\n\n## Issues\n\n- Follow-up to #87