### PR TITLE
Publish Markdown mirrors for docs pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -105,7 +105,7 @@ jobs:
 
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             release_version="${GITHUB_REF_NAME#v}"
-            uv run --group docs python -m slop_guard.docs_site deploy \
+            uv run --group docs python -m tools.docs_site deploy \
               --branch gh-pages \
               --deploy-prefix docs \
               --push \
@@ -119,7 +119,7 @@ jobs:
               --push \
               latest
           else
-            uv run --group docs python -m slop_guard.docs_site deploy \
+            uv run --group docs python -m tools.docs_site deploy \
               --branch gh-pages \
               --deploy-prefix docs \
               --push \

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -105,7 +105,7 @@ jobs:
 
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             release_version="${GITHUB_REF_NAME#v}"
-            uv run --group docs mike deploy \
+            uv run --group docs python -m slop_guard.docs_site deploy \
               --branch gh-pages \
               --deploy-prefix docs \
               --push \
@@ -119,7 +119,7 @@ jobs:
               --push \
               latest
           else
-            uv run --group docs mike deploy \
+            uv run --group docs python -m slop_guard.docs_site deploy \
               --branch gh-pages \
               --deploy-prefix docs \
               --push \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docs-serve:
 	$(UV_DOCS_RUN) zensical serve
 
 docs-build:
-	$(UV_DOCS_RUN) python -m slop_guard.docs_site build
+	$(UV_DOCS_RUN) python -m tools.docs_site build
 
 docs-check: docs-build
 	$(UV_DOCS_RUN) sg -t 60 README.md $$(find docs -type f -name '*.md' | sort)

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docs-serve:
 	$(UV_DOCS_RUN) zensical serve
 
 docs-build:
-	$(UV_DOCS_RUN) zensical build --clean
+	$(UV_DOCS_RUN) python -m slop_guard.docs_site build
 
 docs-check: docs-build
 	$(UV_DOCS_RUN) sg -t 60 README.md $$(find docs -type f -name '*.md' | sort)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -49,4 +49,6 @@ uvx slop-guard==0.4.1
 
 Use the release selector in this documentation site when you want the matching docs for that pinned version.
 
+Every published docs page also exposes a raw Markdown sibling at the same slug. For example, the rendered `get-started` page lives alongside `/docs/get-started.md`, which makes scripted crawling easier for agents and automation.
+
 If you are deciding between a release and `dev (main)`, use a release for stable automation and use `dev (main)` when you are testing current repository behavior before the next tag ships.

--- a/src/slop_guard/docs_site.py
+++ b/src/slop_guard/docs_site.py
@@ -1,0 +1,276 @@
+"""Build and deploy the documentation site with raw Markdown mirrors.
+
+This module keeps the Markdown mirror export in one place so local builds and
+versioned ``mike`` deployments produce the same crawlable assets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, TypeAlias, cast
+
+ConfigMap: TypeAlias = dict[str, Any]
+
+_CONFIG_CANDIDATES: tuple[str, ...] = ("zensical.toml", "mkdocs.yml", "mkdocs.yaml")
+_INDEX_FILENAMES: frozenset[str] = frozenset({"index.md", "README.md"})
+
+
+def resolve_config_file(config_file: str | None) -> Path:
+    """Resolve the documentation config file from the current working tree.
+
+    Args:
+        config_file: Explicit config path, or ``None`` to search default names.
+
+    Returns:
+        The resolved absolute config path.
+
+    Raises:
+        FileNotFoundError: No supported config file exists.
+    """
+    if config_file is not None:
+        return Path(config_file).resolve()
+
+    for candidate in _CONFIG_CANDIDATES:
+        candidate_path = Path(candidate)
+        if candidate_path.exists():
+            return candidate_path.resolve()
+
+    raise FileNotFoundError("No docs config file found.")
+
+
+def markdown_mirror_targets(
+    source_path: Path,
+    docs_dir: Path,
+    site_dir: Path,
+) -> tuple[Path, ...]:
+    """Return the site targets that should mirror one source Markdown page.
+
+    Args:
+        source_path: Source Markdown file inside ``docs_dir``.
+        docs_dir: Root documentation source directory.
+        site_dir: Built site root directory.
+
+    Returns:
+        The raw Markdown targets to write into the built site.
+    """
+    relative_path = source_path.relative_to(docs_dir)
+    targets = [site_dir / relative_path]
+
+    if relative_path.name in _INDEX_FILENAMES and relative_path.parent != Path("."):
+        slug_target = (
+            site_dir / relative_path.parent.parent / (f"{relative_path.parent.name}.md")
+        )
+        targets.append(slug_target)
+
+    return tuple(targets)
+
+
+def publish_markdown_mirrors(docs_dir: Path, site_dir: Path) -> tuple[Path, ...]:
+    """Copy source Markdown pages into crawlable site mirror paths.
+
+    Args:
+        docs_dir: Root documentation source directory.
+        site_dir: Built site root directory.
+
+    Returns:
+        The site paths written during export.
+    """
+    written_paths: list[Path] = []
+    for source_path in sorted(docs_dir.rglob("*.md")):
+        payload = source_path.read_bytes()
+        for target_path in markdown_mirror_targets(source_path, docs_dir, site_dir):
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_bytes(payload)
+            written_paths.append(target_path)
+    return tuple(written_paths)
+
+
+def _load_docs_layout(config_file: Path) -> tuple[Path, Path, ConfigMap]:
+    """Load the docs and site directories from the active Zensical config."""
+    from mike import utils as mike_utils
+
+    config = cast(ConfigMap, mike_utils.load_config(str(config_file)))
+    docs_dir_value = config["docs_dir"]
+    if not isinstance(docs_dir_value, str):
+        raise TypeError("docs_dir must resolve to a string path.")
+    site_dir_value = config["site_dir"]
+    if not isinstance(site_dir_value, str):
+        raise TypeError("site_dir must resolve to a string path.")
+
+    docs_dir = (config_file.parent / docs_dir_value).resolve()
+    site_dir = Path(site_dir_value).resolve()
+    return docs_dir, site_dir, config
+
+
+def _run_zensical_build(config_file: Path, docs_version: str | None) -> None:
+    """Run a clean docs build with an optional Mike docs version."""
+    env = dict(os.environ)
+    if docs_version is None:
+        env.pop("MIKE_DOCS_VERSION", None)
+    else:
+        env["MIKE_DOCS_VERSION"] = docs_version
+
+    subprocess.run(
+        [
+            "zensical",
+            "build",
+            "--clean",
+            "--config-file",
+            str(config_file),
+        ],
+        check=True,
+        env=env,
+    )
+
+
+def build_site(
+    config_file: str | None, docs_version: str | None = None
+) -> tuple[Path, ...]:
+    """Build the docs site and export raw Markdown mirrors.
+
+    Args:
+        config_file: Explicit docs config path, or ``None`` for auto-discovery.
+        docs_version: Optional Mike version injected during the build.
+
+    Returns:
+        The mirror files written into the site output.
+    """
+    resolved_config = resolve_config_file(config_file)
+    _run_zensical_build(resolved_config, docs_version)
+    docs_dir, site_dir, _ = _load_docs_layout(resolved_config)
+    return publish_markdown_mirrors(docs_dir, site_dir)
+
+
+def deploy_site(
+    config_file: str | None,
+    version: str,
+    aliases: Sequence[str],
+    title: str | None,
+    update_aliases: bool,
+    branch: str,
+    remote: str,
+    push: bool,
+    deploy_prefix: str,
+) -> None:
+    """Deploy versioned docs after exporting raw Markdown mirrors.
+
+    Args:
+        config_file: Explicit docs config path, or ``None`` for auto-discovery.
+        version: Version identifier to deploy.
+        aliases: Mike aliases that should point at ``version``.
+        title: Display title for the version selector.
+        update_aliases: Whether existing aliases should be reassigned.
+        branch: Target docs branch.
+        remote: Remote containing the target docs branch.
+        push: Whether to push after committing the deployment.
+        deploy_prefix: Subdirectory inside the docs branch for the site.
+    """
+    from mike import commands, git_utils
+
+    resolved_config = resolve_config_file(config_file)
+    _, _, config = _load_docs_layout(resolved_config)
+    git_utils.update_from_upstream(remote, branch)
+
+    with commands.deploy(
+        config,
+        version,
+        title,
+        list(aliases),
+        update_aliases,
+        commands.AliasType.symlink,
+        None,
+        branch=branch,
+        deploy_prefix=deploy_prefix,
+    ):
+        build_site(str(resolved_config), docs_version=version)
+
+    if push:
+        git_utils.push_branch(remote, branch)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the module command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Build or deploy docs with raw Markdown mirrors."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_parser = subparsers.add_parser(
+        "build",
+        help="Build the local docs site and export Markdown mirrors.",
+    )
+    build_parser.add_argument(
+        "--config-file",
+        default=None,
+        help="Path to the docs config file.",
+    )
+
+    deploy_parser = subparsers.add_parser(
+        "deploy",
+        help="Deploy versioned docs and export Markdown mirrors.",
+    )
+    deploy_parser.add_argument("version", help="Version to deploy.")
+    deploy_parser.add_argument("aliases", nargs="*", help="Aliases for the version.")
+    deploy_parser.add_argument("--config-file", default=None, help="Docs config file.")
+    deploy_parser.add_argument("--title", default=None, help="Display title.")
+    deploy_parser.add_argument(
+        "--update-aliases",
+        action="store_true",
+        help="Repoint aliases that already exist.",
+    )
+    deploy_parser.add_argument(
+        "--branch",
+        default="gh-pages",
+        help="Target branch for versioned docs.",
+    )
+    deploy_parser.add_argument(
+        "--remote",
+        default="origin",
+        help="Git remote for the docs branch.",
+    )
+    deploy_parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Push the docs branch after deployment.",
+    )
+    deploy_parser.add_argument(
+        "--deploy-prefix",
+        default="",
+        help="Subdirectory inside the docs branch for the site.",
+    )
+
+    return parser
+
+
+def main() -> None:
+    """Run the docs site helper CLI."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.command == "build":
+        build_site(args.config_file)
+        return
+
+    if args.command == "deploy":
+        deploy_site(
+            args.config_file,
+            args.version,
+            args.aliases,
+            args.title,
+            args.update_aliases,
+            args.branch,
+            args.remote,
+            args.push,
+            args.deploy_prefix,
+        )
+        return
+
+    raise ValueError(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/slop_guard/docs_site.py
+++ b/src/slop_guard/docs_site.py
@@ -7,6 +7,7 @@ versioned ``mike`` deployments produce the same crawlable assets.
 from __future__ import annotations
 
 import argparse
+import importlib
 import os
 import subprocess
 from collections.abc import Sequence
@@ -91,8 +92,7 @@ def publish_markdown_mirrors(docs_dir: Path, site_dir: Path) -> tuple[Path, ...]
 
 def _load_docs_layout(config_file: Path) -> tuple[Path, Path, ConfigMap]:
     """Load the docs and site directories from the active Zensical config."""
-    from mike import utils as mike_utils
-
+    mike_utils = cast(Any, importlib.import_module("mike.utils"))
     config = cast(ConfigMap, mike_utils.load_config(str(config_file)))
     docs_dir_value = config["docs_dir"]
     if not isinstance(docs_dir_value, str):
@@ -169,19 +169,19 @@ def deploy_site(
         push: Whether to push after committing the deployment.
         deploy_prefix: Subdirectory inside the docs branch for the site.
     """
-    from mike import commands, git_utils
-
+    mike_commands = cast(Any, importlib.import_module("mike.commands"))
+    mike_git_utils = cast(Any, importlib.import_module("mike.git_utils"))
     resolved_config = resolve_config_file(config_file)
     _, _, config = _load_docs_layout(resolved_config)
-    git_utils.update_from_upstream(remote, branch)
+    mike_git_utils.update_from_upstream(remote, branch)
 
-    with commands.deploy(
+    with mike_commands.deploy(
         config,
         version,
         title,
         list(aliases),
         update_aliases,
-        commands.AliasType.symlink,
+        mike_commands.AliasType.symlink,
         None,
         branch=branch,
         deploy_prefix=deploy_prefix,
@@ -189,7 +189,7 @@ def deploy_site(
         build_site(str(resolved_config), docs_version=version)
 
     if push:
-        git_utils.push_branch(remote, branch)
+        mike_git_utils.push_branch(remote, branch)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -109,13 +109,17 @@ def test_load_docs_layout_reads_paths_from_mike_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Docs layout loading should resolve docs and site directories from Mike."""
-    fake_utils = types.SimpleNamespace(
+    fake_utils_module = types.SimpleNamespace(
         load_config=lambda _: {
             "docs_dir": "docs",
             "site_dir": str(tmp_path / "site"),
         }
     )
-    monkeypatch.setitem(sys.modules, "mike", types.SimpleNamespace(utils=fake_utils))
+    monkeypatch.setattr(
+        docs_site.importlib,
+        "import_module",
+        lambda name: fake_utils_module if name == "mike.utils" else None,
+    )
     config_path = tmp_path / "zensical.toml"
     config_path.write_text("", encoding="utf-8")
 
@@ -131,13 +135,17 @@ def test_load_docs_layout_requires_string_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Docs layout loading should reject non-string config paths."""
-    fake_utils = types.SimpleNamespace(
+    fake_utils_module = types.SimpleNamespace(
         load_config=lambda _: {
             "docs_dir": object(),
             "site_dir": str(tmp_path / "site"),
         }
     )
-    monkeypatch.setitem(sys.modules, "mike", types.SimpleNamespace(utils=fake_utils))
+    monkeypatch.setattr(
+        docs_site.importlib,
+        "import_module",
+        lambda name: fake_utils_module if name == "mike.utils" else None,
+    )
     config_path = tmp_path / "zensical.toml"
     config_path.write_text("", encoding="utf-8")
 
@@ -241,10 +249,13 @@ def test_deploy_site_wraps_build_with_mike_deploy(
         ),
         push_branch=lambda remote, branch: push_calls.append((remote, branch)),
     )
-    monkeypatch.setitem(
-        sys.modules,
-        "mike",
-        types.SimpleNamespace(commands=fake_commands, git_utils=fake_git_utils),
+    monkeypatch.setattr(
+        docs_site.importlib,
+        "import_module",
+        lambda name: {
+            "mike.commands": fake_commands,
+            "mike.git_utils": fake_git_utils,
+        }[name],
     )
     monkeypatch.setattr(docs_site, "resolve_config_file", lambda _: config_path)
     monkeypatch.setattr(

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -1,0 +1,352 @@
+"""Tests for docs-site Markdown mirror publishing."""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import slop_guard.docs_site as docs_site
+from slop_guard.docs_site import markdown_mirror_targets, publish_markdown_mirrors
+
+
+def test_markdown_mirror_targets_preserve_standard_markdown_paths() -> None:
+    """Non-index Markdown pages should keep a single mirrored site path."""
+    docs_dir = Path("/tmp/docs")
+    site_dir = Path("/tmp/site")
+
+    targets = markdown_mirror_targets(docs_dir / "guide.md", docs_dir, site_dir)
+
+    assert targets == (site_dir / "guide.md",)
+
+
+def test_markdown_mirror_targets_add_slug_alias_for_nested_index_pages() -> None:
+    """Section index pages should also publish a sibling ``.md`` slug file."""
+    docs_dir = Path("/tmp/docs")
+    site_dir = Path("/tmp/site")
+
+    targets = markdown_mirror_targets(
+        docs_dir / "guides" / "install" / "index.md",
+        docs_dir,
+        site_dir,
+    )
+
+    assert targets == (
+        site_dir / "guides" / "install" / "index.md",
+        site_dir / "guides" / "install.md",
+    )
+
+
+def test_publish_markdown_mirrors_writes_source_bytes_to_all_targets(
+    tmp_path: Path,
+) -> None:
+    """Mirror publishing should copy source Markdown to every exported path."""
+    docs_dir = tmp_path / "docs"
+    site_dir = tmp_path / "site"
+    nested_dir = docs_dir / "guides" / "install"
+    nested_dir.mkdir(parents=True)
+    guide_path = docs_dir / "guide.md"
+    guide_path.write_text("# Guide\n", encoding="utf-8")
+    index_path = nested_dir / "index.md"
+    index_path.write_text("# Install\n", encoding="utf-8")
+
+    written = publish_markdown_mirrors(docs_dir, site_dir)
+
+    assert written == (
+        site_dir / "guide.md",
+        site_dir / "guides" / "install" / "index.md",
+        site_dir / "guides" / "install.md",
+    )
+    assert (site_dir / "guide.md").read_text(encoding="utf-8") == "# Guide\n"
+    assert (site_dir / "guides" / "install" / "index.md").read_text(
+        encoding="utf-8"
+    ) == "# Install\n"
+    assert (site_dir / "guides" / "install.md").read_text(encoding="utf-8") == (
+        "# Install\n"
+    )
+
+
+def test_resolve_config_file_prefers_explicit_path(tmp_path: Path) -> None:
+    """Explicit config paths should bypass repository auto-discovery."""
+    config_path = tmp_path / "zensical.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    resolved = docs_site.resolve_config_file(str(config_path))
+
+    assert resolved == config_path.resolve()
+
+
+def test_resolve_config_file_discovers_default_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-discovery should return the first supported config present."""
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "zensical.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    resolved = docs_site.resolve_config_file(None)
+
+    assert resolved == config_path.resolve()
+
+
+def test_resolve_config_file_raises_when_no_supported_file_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-discovery should fail loudly when no config file exists."""
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        docs_site.resolve_config_file(None)
+
+
+def test_load_docs_layout_reads_paths_from_mike_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Docs layout loading should resolve docs and site directories from Mike."""
+    fake_utils = types.SimpleNamespace(
+        load_config=lambda _: {
+            "docs_dir": "docs",
+            "site_dir": str(tmp_path / "site"),
+        }
+    )
+    monkeypatch.setitem(sys.modules, "mike", types.SimpleNamespace(utils=fake_utils))
+    config_path = tmp_path / "zensical.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    docs_dir, site_dir, config = docs_site._load_docs_layout(config_path)
+
+    assert docs_dir == (tmp_path / "docs").resolve()
+    assert site_dir == (tmp_path / "site").resolve()
+    assert config["docs_dir"] == "docs"
+
+
+def test_load_docs_layout_requires_string_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Docs layout loading should reject non-string config paths."""
+    fake_utils = types.SimpleNamespace(
+        load_config=lambda _: {
+            "docs_dir": object(),
+            "site_dir": str(tmp_path / "site"),
+        }
+    )
+    monkeypatch.setitem(sys.modules, "mike", types.SimpleNamespace(utils=fake_utils))
+    config_path = tmp_path / "zensical.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(TypeError):
+        docs_site._load_docs_layout(config_path)
+
+
+def test_run_zensical_build_sets_or_clears_docs_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Build invocation should manage the Mike docs-version environment."""
+    calls: list[tuple[list[str], dict[str, str]]] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        env: dict[str, str],
+    ) -> None:
+        assert check is True
+        calls.append((command, env))
+
+    monkeypatch.setattr(docs_site.subprocess, "run", fake_run)
+    monkeypatch.setenv("MIKE_DOCS_VERSION", "stale")
+    config_path = tmp_path / "zensical.toml"
+
+    docs_site._run_zensical_build(config_path, "1.2.3")
+    docs_site._run_zensical_build(config_path, None)
+
+    assert calls[0][0] == [
+        "zensical",
+        "build",
+        "--clean",
+        "--config-file",
+        str(config_path),
+    ]
+    assert calls[0][1]["MIKE_DOCS_VERSION"] == "1.2.3"
+    assert "MIKE_DOCS_VERSION" not in calls[1][1]
+
+
+def test_build_site_runs_build_then_exports_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Site building should run Zensical and then publish Markdown mirrors."""
+    config_path = tmp_path / "zensical.toml"
+    docs_dir = tmp_path / "docs"
+    site_dir = tmp_path / "site"
+    build_calls: list[tuple[Path, str | None]] = []
+
+    monkeypatch.setattr(docs_site, "resolve_config_file", lambda _: config_path)
+    monkeypatch.setattr(
+        docs_site,
+        "_run_zensical_build",
+        lambda path, version: build_calls.append((path, version)),
+    )
+    monkeypatch.setattr(
+        docs_site,
+        "_load_docs_layout",
+        lambda _: (docs_dir, site_dir, {}),
+    )
+    monkeypatch.setattr(
+        docs_site,
+        "publish_markdown_mirrors",
+        lambda docs_root, site_root: (site_root / "guide.md",),
+    )
+
+    written = docs_site.build_site(None, docs_version="dev")
+
+    assert build_calls == [(config_path, "dev")]
+    assert written == (site_dir / "guide.md",)
+
+
+def test_deploy_site_wraps_build_with_mike_deploy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deployment should export mirrors before Mike commits the built site."""
+    config_path = tmp_path / "zensical.toml"
+    build_calls: list[tuple[str | None, str | None]] = []
+    update_calls: list[tuple[str, str]] = []
+    push_calls: list[tuple[str, str]] = []
+    deploy_records: list[tuple[object, ...]] = []
+    context_state = {"entered": False}
+
+    @contextlib.contextmanager
+    def fake_deploy(*args: object, **kwargs: object):
+        deploy_records.append(args + (kwargs,))
+        context_state["entered"] = True
+        yield
+        context_state["entered"] = False
+
+    fake_commands = types.SimpleNamespace(
+        AliasType=types.SimpleNamespace(symlink="symlink"),
+        deploy=fake_deploy,
+    )
+    fake_git_utils = types.SimpleNamespace(
+        update_from_upstream=lambda remote, branch: update_calls.append(
+            (remote, branch)
+        ),
+        push_branch=lambda remote, branch: push_calls.append((remote, branch)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mike",
+        types.SimpleNamespace(commands=fake_commands, git_utils=fake_git_utils),
+    )
+    monkeypatch.setattr(docs_site, "resolve_config_file", lambda _: config_path)
+    monkeypatch.setattr(
+        docs_site,
+        "_load_docs_layout",
+        lambda _: (tmp_path / "docs", tmp_path / "site", {"site_dir": "site"}),
+    )
+
+    def fake_build_site(
+        config_file: str | None, docs_version: str | None
+    ) -> tuple[Path]:
+        assert context_state["entered"] is True
+        build_calls.append((config_file, docs_version))
+        return (tmp_path / "site" / "guide.md",)
+
+    monkeypatch.setattr(docs_site, "build_site", fake_build_site)
+
+    docs_site.deploy_site(
+        None,
+        "1.2.3",
+        ("latest",),
+        "v1.2.3",
+        True,
+        "gh-pages",
+        "origin",
+        True,
+        "docs",
+    )
+
+    assert update_calls == [("origin", "gh-pages")]
+    assert push_calls == [("origin", "gh-pages")]
+    assert build_calls == [(str(config_path), "1.2.3")]
+    assert deploy_records == [
+        (
+            {"site_dir": "site"},
+            "1.2.3",
+            "v1.2.3",
+            ["latest"],
+            True,
+            "symlink",
+            None,
+            {"branch": "gh-pages", "deploy_prefix": "docs"},
+        )
+    ]
+
+
+def test_main_dispatches_build_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI main should route the build subcommand to ``build_site``."""
+    build_calls: list[str | None] = []
+    monkeypatch.setattr(sys, "argv", ["docs_site.py", "build", "--config-file", "cfg"])
+    monkeypatch.setattr(
+        docs_site,
+        "build_site",
+        lambda config_file: build_calls.append(config_file),
+    )
+
+    docs_site.main()
+
+    assert build_calls == ["cfg"]
+
+
+def test_main_dispatches_deploy_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI main should route the deploy subcommand to ``deploy_site``."""
+    deploy_calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "docs_site.py",
+            "deploy",
+            "1.2.3",
+            "latest",
+            "--title",
+            "v1.2.3",
+            "--update-aliases",
+            "--branch",
+            "gh-pages",
+            "--remote",
+            "origin",
+            "--push",
+            "--deploy-prefix",
+            "docs",
+        ],
+    )
+    monkeypatch.setattr(
+        docs_site,
+        "deploy_site",
+        lambda *args: deploy_calls.append(args),
+    )
+
+    docs_site.main()
+
+    assert deploy_calls == [
+        (
+            None,
+            "1.2.3",
+            ["latest"],
+            "v1.2.3",
+            True,
+            "gh-pages",
+            "origin",
+            True,
+            "docs",
+        )
+    ]

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -3,14 +3,32 @@
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import sys
 import types
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-import slop_guard.docs_site as docs_site
-from slop_guard.docs_site import markdown_mirror_targets, publish_markdown_mirrors
+_DOCS_SITE_PATH = Path(__file__).resolve().parents[1] / "tools" / "docs_site.py"
+
+
+def _load_docs_site_module() -> Any:
+    """Load the repo-local docs helper module directly from disk."""
+    spec = importlib.util.spec_from_file_location("tools.docs_site", _DOCS_SITE_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError(
+            f"Unable to load docs helper module from {_DOCS_SITE_PATH}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+docs_site = _load_docs_site_module()
+markdown_mirror_targets = docs_site.markdown_mirror_targets
+publish_markdown_mirrors = docs_site.publish_markdown_mirrors
 
 
 def test_markdown_mirror_targets_preserve_standard_markdown_paths() -> None:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local helper modules that are not part of the published wheel."""

--- a/tools/docs_site.py
+++ b/tools/docs_site.py
@@ -1,7 +1,7 @@
 """Build and deploy the documentation site with raw Markdown mirrors.
 
-This module keeps the Markdown mirror export in one place so local builds and
-versioned ``mike`` deployments produce the same crawlable assets.
+This helper is intentionally repo-local so the published library does not ship
+documentation-only build logic.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Description

This PR publishes a raw Markdown mirror for every built docs page. Local `make docs-build` now writes `.md` files into `site/`, and the Pages deploy path uses the same repo-local helper under `tools/` before `mike` commits a version, so every published docs version and alias keeps the HTML page plus a crawlable Markdown sibling without adding docs-only code to the shipped library package.

## Why?

Agents and other scripted clients can consume the docs more reliably when each page has a direct Markdown URL. Publishing those mirrors in the build pipeline avoids hand-maintained copies, keeps the raw page content aligned with the rendered site, and keeps the core library focused on runtime functionality instead of documentation tooling.

## Usage / Demonstration

```text
/docs/get-started/     -> rendered page
/docs/get-started.md   -> raw Markdown mirror

/docs/agents/          -> rendered page
/docs/agents.md        -> raw Markdown mirror
```

Local verification:

```bash
make docs-build
find site -maxdepth 2 -name '*.md' | sort
```

## Verification

- Ran `make check`
- Ran `make docs-check`
- Ran `uv run --group docs python -m tools.docs_site build`
- Verified the build emits `site/index.md`, `site/get-started.md`, and `site/agents.md`

## Issues

- None.
