### PR TITLE
Add intra-sentence keyword bold rule

### DIFF
--- a/src/slop_guard/config.py
+++ b/src/slop_guard/config.py
@@ -45,6 +45,10 @@ class Hyperparameters:
     contrast_record_cap: int = 5
     contrast_penalty: int = -1
     contrast_advice_min: int = 2
+    intrasentence_keyword_bold_penalty: int = -2
+    intrasentence_keyword_bold_record_cap: int = 5
+    intrasentence_keyword_bold_advice_min: int = 3
+    intrasentence_keyword_bold_max_words: int = 5
     setup_resolution_record_cap: int = 5
     setup_resolution_penalty: int = -3
     colon_words_basis: float = 150.0

--- a/src/slop_guard/rules/assets/default.jsonl
+++ b/src/slop_guard/rules/assets/default.jsonl
@@ -8,6 +8,7 @@
 {"config": {"cv_threshold": 0.3, "min_sentences": 5, "penalty": -5}, "rule_type": "slop_guard.rules.passage.rhythm.RhythmRule"}
 {"config": {"density_threshold": 1.0, "penalty": -3, "words_basis": 150.0}, "rule_type": "slop_guard.rules.passage.em_dash_density.EmDashDensityRule"}
 {"config": {"advice_min": 2, "context_window_chars": 60, "penalty": -1, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence.contrast_pair.ContrastPairRule"}
+{"config": {"advice_min": 3, "context_window_chars": 60, "max_words": 5, "penalty": -2, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence.intrasentence_keyword_bold.IntrasentenceKeywordBoldRule"}
 {"config": {"context_window_chars": 60, "penalty": -3, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence.setup_resolution.SetupResolutionRule"}
 {"config": {"density_threshold": 1.5, "penalty": -3, "words_basis": 150.0}, "rule_type": "slop_guard.rules.passage.colon_density.ColonDensityRule"}
 {"config": {"max_sentence_words": 6, "penalty": -2, "record_cap": 3}, "rule_type": "slop_guard.rules.sentence.pithy_fragment.PithyFragmentRule"}

--- a/src/slop_guard/rules/catalog.py
+++ b/src/slop_guard/rules/catalog.py
@@ -11,6 +11,7 @@ DEFAULT_RULE_PATHS: tuple[str, ...] = (
     "slop_guard.rules.passage.rhythm.RhythmRule",
     "slop_guard.rules.passage.em_dash_density.EmDashDensityRule",
     "slop_guard.rules.sentence.contrast_pair.ContrastPairRule",
+    "slop_guard.rules.sentence.intrasentence_keyword_bold.IntrasentenceKeywordBoldRule",
     "slop_guard.rules.sentence.setup_resolution.SetupResolutionRule",
     "slop_guard.rules.passage.colon_density.ColonDensityRule",
     "slop_guard.rules.sentence.pithy_fragment.PithyFragmentRule",

--- a/src/slop_guard/rules/sentence/__init__.py
+++ b/src/slop_guard/rules/sentence/__init__.py
@@ -2,6 +2,10 @@
 
 from .ai_disclosure import AIDisclosureRule, AIDisclosureRuleConfig
 from .contrast_pair import ContrastPairRule, ContrastPairRuleConfig
+from .intrasentence_keyword_bold import (
+    IntrasentenceKeywordBoldRule,
+    IntrasentenceKeywordBoldRuleConfig,
+)
 from .pithy_fragment import PithyFragmentRule, PithyFragmentRuleConfig
 from .placeholder import PlaceholderRule, PlaceholderRuleConfig
 from .setup_resolution import SetupResolutionRule, SetupResolutionRuleConfig
@@ -14,6 +18,8 @@ __all__ = [
     "AIDisclosureRuleConfig",
     "ContrastPairRule",
     "ContrastPairRuleConfig",
+    "IntrasentenceKeywordBoldRule",
+    "IntrasentenceKeywordBoldRuleConfig",
     "PithyFragmentRule",
     "PithyFragmentRuleConfig",
     "PlaceholderRule",

--- a/src/slop_guard/rules/sentence/intrasentence_keyword_bold.py
+++ b/src/slop_guard/rules/sentence/intrasentence_keyword_bold.py
@@ -43,6 +43,11 @@ _BLOCKQUOTE_LINE_RE = re.compile(r"^\s*>")
 _BULLET_LIKE_LINE_RE = re.compile(r"^\s*[-*]\s|^\s*\d+[.)]\s")
 _NUMERIC_BOLD_RE = re.compile(r"^[\s$%€£¥+\-.,]*\d[\s\d.,$%€£¥+\-]*[%a-zA-Z]{0,4}$")
 _WORD_TOKEN_RE = re.compile(r"\w+")
+# Mirror StructuralPatternRule._BOLD_HEADER_RE: ``**Term[.:]**`` is a label form
+# only when followed by ``\s+\S`` continuation. Standalone or sentence-final
+# variants are NOT covered by the structural rule, so this rule must catch them.
+_LABEL_CONTINUATION_RE = re.compile(r"\s+\S")
+_SENTENCE_TERMINATORS = frozenset(".!?")
 
 KeywordBoldMatch: TypeAlias = tuple[int, int, str]
 
@@ -70,14 +75,49 @@ def _is_excluded_line(line: str) -> bool:
     )
 
 
-def _is_label_form(inner_text: str) -> bool:
-    """Return whether the bold inner text ends in label punctuation.
+def _is_label_form_with_continuation(
+    masked_text: str, match_end: int, inner_text: str
+) -> bool:
+    """Return whether the bold span is a structural-rule label form.
 
-    The ``**Term:**`` and ``**Term.**`` shapes are already covered by
-    :class:`StructuralPatternRule`'s bold-header detection, so this rule must
-    not double-count them.
+    :class:`StructuralPatternRule`'s ``_BOLD_HEADER_RE`` only catches
+    ``**Term[.:]**`` when followed by ``\\s+\\S`` (whitespace + continuation),
+    so this exclusion must mirror that shape exactly. A sentence-final
+    ``**careful planning.**`` with no trailing content is NOT covered by the
+    structural rule, so it should still be flagged here as keyword emphasis.
     """
-    return inner_text.endswith(":") or inner_text.endswith(".")
+    if not (inner_text.endswith(":") or inner_text.endswith(".")):
+        return False
+    return _LABEL_CONTINUATION_RE.match(masked_text, match_end) is not None
+
+
+def _begins_paragraph_or_sentence(masked_text: str, start: int) -> bool:
+    """Return whether the bold span at ``start`` opens a paragraph or sentence.
+
+    The span is considered to begin (rather than be embedded in) a sentence
+    when, looking backward over the code-masked projection, the preceding
+    non-whitespace is a sentence terminator, a paragraph break, or the
+    document start. A bold span that survives this check is genuinely
+    mid-sentence keyword emphasis.
+
+    The masked projection is walked so ``.`` characters inside inline code or
+    fenced blocks aren't mistaken for sentence ends. ``\\r`` is included in the
+    inline-whitespace set so CRLF line endings behave the same as LF.
+    """
+    head = masked_text[:start].rstrip(" \t\r")
+    if not head:
+        return True
+    if head[-1] in _SENTENCE_TERMINATORS:
+        return True
+    if head[-1] != "\n":
+        return False
+    # Crossed one soft newline; strip it and re-inspect what precedes.
+    head = head[:-1].rstrip(" \t\r")
+    if not head:
+        return True
+    if head[-1] == "\n":
+        return True  # paragraph break (``\n[ \t\r]*\n``)
+    return head[-1] in _SENTENCE_TERMINATORS
 
 
 def _is_numeric_only(inner_text: str) -> bool:
@@ -110,15 +150,15 @@ def _collect_keyword_bold_matches(
 
     for match in _BOLD_SPAN_RE.finditer(masked):
         inner = match.group(1)
-        if _is_label_form(inner):
+        start = match.start()
+        end = match.end()
+        if _is_label_form_with_continuation(masked, end, inner):
             continue
         if _is_numeric_only(inner):
             continue
         if _word_count(inner) > max_words:
             continue
 
-        start = match.start()
-        end = match.end()
         line_index = _line_index_for_offset(line_starts, start)
         line_start_offset = line_starts[line_index]
         line_end_offset = (
@@ -130,8 +170,7 @@ def _collect_keyword_bold_matches(
         if _is_excluded_line(line_text):
             continue
 
-        prefix_on_line = text[line_start_offset:start]
-        if not prefix_on_line.strip():
+        if _begins_paragraph_or_sentence(masked, start):
             continue
 
         survivors.append((start, end, text[start:end]))
@@ -208,7 +247,9 @@ class IntrasentenceKeywordBoldRule(Rule[IntrasentenceKeywordBoldRuleConfig]):
         return RuleResult(
             violations=violations,
             advice=advice,
-            count_deltas={self.count_key: len(violations)} if violations else {},
+            # Report the true prevalence (not the capped sample) so concentration
+            # amplification and user-facing counts reflect what's in the document.
+            count_deltas={self.count_key: len(matches)} if matches else {},
         )
 
     def _fit(

--- a/src/slop_guard/rules/sentence/intrasentence_keyword_bold.py
+++ b/src/slop_guard/rules/sentence/intrasentence_keyword_bold.py
@@ -1,0 +1,279 @@
+"""Detect short, mid-sentence keyword bold spans (LLM emphasis tic).
+
+Objective: Identify ``**short**`` Markdown bold spans appearing inside flowing
+prose, used as keyword emphasis. This pattern is a common LLM stylistic tic
+where models bold a word or short phrase mid-sentence to mimic glossary or
+keyword formatting where none is warranted.
+
+Example Rule Violations:
+    - "We need to **carefully consider** all the options before deciding."
+      Mid-sentence bold span used as arbitrary keyword emphasis.
+    - "The system must remain **highly available** during peak hours."
+      Two-word emphasis inserted into otherwise normal prose.
+
+Example Non-Violations:
+    - "**Note:** make sure to back up your data first."
+      Bold acts as a labeled lead-in at the start of the line.
+    - "## A section heading without inline emphasis"
+      Markdown heading line with no inline bold.
+    - "The release shipped on schedule and the team celebrated."
+      Plain prose without any bold formatting.
+
+Severity: Low per instance, medium when repeated frequently in one passage.
+"""
+
+import math
+import re
+from bisect import bisect_right
+from dataclasses import dataclass
+from typing import TypeAlias
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import (
+    fit_count_cap_contrastive,
+    fit_penalty_contrastive,
+    fit_threshold_high_contrastive,
+)
+
+_BOLD_SPAN_RE = re.compile(r"\*\*([^*\n]+?)\*\*")
+_HEADING_LINE_RE = re.compile(r"^\s*#")
+_BLOCKQUOTE_LINE_RE = re.compile(r"^\s*>")
+_BULLET_LIKE_LINE_RE = re.compile(r"^\s*[-*]\s|^\s*\d+[.)]\s")
+_NUMERIC_BOLD_RE = re.compile(r"^[\s$%€£¥+\-.,]*\d[\s\d.,$%€£¥+\-]*[%a-zA-Z]{0,4}$")
+_WORD_TOKEN_RE = re.compile(r"\w+")
+
+KeywordBoldMatch: TypeAlias = tuple[int, int, str]
+
+
+def _line_start_offsets(text: str) -> tuple[int, ...]:
+    """Return cumulative line-start character offsets for ``text``."""
+    offsets = [0]
+    for index, char in enumerate(text):
+        if char == "\n":
+            offsets.append(index + 1)
+    return tuple(offsets)
+
+
+def _line_index_for_offset(line_starts: tuple[int, ...], offset: int) -> int:
+    """Return the line index whose span contains ``offset``."""
+    return max(0, bisect_right(line_starts, offset) - 1)
+
+
+def _is_excluded_line(line: str) -> bool:
+    """Return whether ``line`` is a non-prose context where bold is allowed."""
+    return (
+        _HEADING_LINE_RE.match(line) is not None
+        or _BLOCKQUOTE_LINE_RE.match(line) is not None
+        or _BULLET_LIKE_LINE_RE.match(line) is not None
+    )
+
+
+def _is_label_form(inner_text: str) -> bool:
+    """Return whether the bold inner text ends in label punctuation.
+
+    The ``**Term:**`` and ``**Term.**`` shapes are already covered by
+    :class:`StructuralPatternRule`'s bold-header detection, so this rule must
+    not double-count them.
+    """
+    return inner_text.endswith(":") or inner_text.endswith(".")
+
+
+def _is_numeric_only(inner_text: str) -> bool:
+    """Return whether the bold inner text is purely numeric or unit-tagged."""
+    return _NUMERIC_BOLD_RE.match(inner_text) is not None
+
+
+def _word_count(text: str) -> int:
+    """Return the alphanumeric word-token count for ``text``."""
+    return len(_WORD_TOKEN_RE.findall(text))
+
+
+def _collect_keyword_bold_matches(
+    document: AnalysisDocument, max_words: int
+) -> tuple[KeywordBoldMatch, ...]:
+    """Return surviving mid-sentence keyword bold matches.
+
+    Args:
+        document: Source document providing text and Markdown projections.
+        max_words: Maximum word count of the bold span's inner text.
+
+    Returns:
+        Ordered ``(start, end, snippet)`` tuples for spans that pass every
+        keyword-bold filter.
+    """
+    text = document.text
+    masked = document.text_with_markdown_code_masked
+    line_starts = _line_start_offsets(text)
+    survivors: list[KeywordBoldMatch] = []
+
+    for match in _BOLD_SPAN_RE.finditer(masked):
+        inner = match.group(1)
+        if _is_label_form(inner):
+            continue
+        if _is_numeric_only(inner):
+            continue
+        if _word_count(inner) > max_words:
+            continue
+
+        start = match.start()
+        end = match.end()
+        line_index = _line_index_for_offset(line_starts, start)
+        line_start_offset = line_starts[line_index]
+        line_end_offset = (
+            line_starts[line_index + 1] - 1
+            if line_index + 1 < len(line_starts)
+            else len(text)
+        )
+        line_text = text[line_start_offset:line_end_offset]
+        if _is_excluded_line(line_text):
+            continue
+
+        prefix_on_line = text[line_start_offset:start]
+        if not prefix_on_line.strip():
+            continue
+
+        survivors.append((start, end, text[start:end]))
+
+    return tuple(survivors)
+
+
+@dataclass
+class IntrasentenceKeywordBoldRuleConfig(RuleConfig):
+    """Config for the intra-sentence keyword bold detector."""
+
+    penalty: int
+    record_cap: int
+    advice_min: int
+    max_words: int
+    context_window_chars: int
+
+
+class IntrasentenceKeywordBoldRule(Rule[IntrasentenceKeywordBoldRuleConfig]):
+    """Detect short Markdown bold spans appearing mid-sentence in prose."""
+
+    name = "intrasentence_keyword_bold"
+    count_key = "intrasentence_keyword_bold"
+    level = RuleLevel.SENTENCE
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger keyword-bold matches."""
+        return [
+            "We need to **carefully consider** all the options before deciding.",
+            "The system must remain **highly available** during peak hours.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid keyword-bold matches."""
+        return [
+            "**Note:** make sure to back up your data first.",
+            "## A section heading without inline emphasis",
+            "The release shipped on schedule and the team celebrated.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Apply keyword-bold detection and aggregate advice."""
+        matches = _collect_keyword_bold_matches(document, self.config.max_words)
+        violations: list[Violation] = []
+        advice: list[str] = []
+
+        for start, end, snippet in matches[: self.config.record_cap]:
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match=snippet,
+                    context=context_around(
+                        document.text,
+                        start,
+                        end,
+                        width=self.config.context_window_chars,
+                    ),
+                    penalty=self.config.penalty,
+                    start=start,
+                    end=end,
+                )
+            )
+            advice.append(
+                f"Drop the mid-sentence bold around '{snippet}' \u2014 use plain "
+                "prose instead of keyword emphasis."
+            )
+
+        if len(matches) >= self.config.advice_min:
+            advice.append(
+                f"{len(matches)} mid-sentence keyword bolds \u2014 stop using "
+                "**emphasis** to highlight keywords inside running prose."
+            )
+
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)} if violations else {},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> IntrasentenceKeywordBoldRuleConfig:
+        """Fit cap and penalty from positive vs negative bold prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        positive_counts = [
+            len(
+                _collect_keyword_bold_matches(
+                    AnalysisDocument.from_text(sample), self.config.max_words
+                )
+            )
+            for sample in positive_samples
+        ]
+        negative_counts = [
+            len(
+                _collect_keyword_bold_matches(
+                    AnalysisDocument.from_text(sample), self.config.max_words
+                )
+            )
+            for sample in negative_samples
+        ]
+        positive_matches = sum(1 for count in positive_counts if count > 0)
+        negative_matches = sum(1 for count in negative_counts if count > 0)
+        positive_nonzero = [count for count in positive_counts if count > 0]
+        negative_nonzero = [count for count in negative_counts if count > 0]
+
+        record_cap = fit_count_cap_contrastive(
+            default_value=self.config.record_cap,
+            positive_values=positive_nonzero or [self.config.record_cap],
+            negative_values=negative_nonzero,
+            lower=1,
+            upper=64,
+            positive_quantile=0.90,
+            negative_quantile=0.75,
+            blend_pivot=18.0,
+        )
+        advice_min = math.ceil(
+            fit_threshold_high_contrastive(
+                default_value=float(self.config.advice_min),
+                positive_values=positive_counts,
+                negative_values=negative_counts,
+                lower=1.0,
+                upper=64.0,
+                positive_quantile=0.75,
+                negative_quantile=0.25,
+                blend_pivot=18.0,
+                match_mode="ge",
+            )
+        )
+
+        return IntrasentenceKeywordBoldRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            record_cap=record_cap,
+            advice_min=advice_min,
+            max_words=self.config.max_words,
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/scoring.py
+++ b/src/slop_guard/scoring.py
@@ -19,6 +19,7 @@ _COUNT_KEYS: tuple[str, ...] = (
     "rhythm",
     "em_dash",
     "contrast_pairs",
+    "intrasentence_keyword_bold",
     "setup_resolution",
     "colon_density",
     "pithy_fragment",

--- a/tests/test_analysis_pipeline.py
+++ b/tests/test_analysis_pipeline.py
@@ -192,10 +192,12 @@ def test_analyze_short_text_exposes_full_count_schema() -> None:
         "closing_aphorism",
         "copula_chain",
         "extreme_sentence",
+        "intrasentence_keyword_bold",
         "paragraph_balance",
         "paragraph_cv",
     }.issubset(result["counts"])
     assert result["counts"]["closing_aphorism"] == 0
+    assert result["counts"]["intrasentence_keyword_bold"] == 0
     assert result["counts"]["paragraph_cv"] == 0
 
 

--- a/tests/test_intrasentence_keyword_bold_rule.py
+++ b/tests/test_intrasentence_keyword_bold_rule.py
@@ -51,7 +51,7 @@ def test_flags_multiple_keyword_bolds_and_emits_summary() -> None:
 
 
 def test_record_cap_limits_emitted_violations() -> None:
-    """Violations are capped at record_cap even when more matches exist."""
+    """Violations cap at record_cap but count_deltas reports true prevalence."""
     rule = IntrasentenceKeywordBoldRule(
         IntrasentenceKeywordBoldRuleConfig(
             penalty=-2,
@@ -68,7 +68,9 @@ def test_record_cap_limits_emitted_violations() -> None:
 
     result = rule.forward(AnalysisDocument.from_text(text))
 
-    assert result.count_deltas == {"intrasentence_keyword_bold": 2}
+    # All five mid-sentence bolds count toward the document's prevalence so
+    # concentration amplification sees the true frequency, not the sample cap.
+    assert result.count_deltas == {"intrasentence_keyword_bold": 5}
     assert len(result.violations) == 2
 
 
@@ -214,6 +216,122 @@ def test_advice_min_threshold_emits_summary_only_when_met() -> None:
 
     assert not any("mid-sentence keyword bolds" in line for line in one_result.advice)
     assert any("mid-sentence keyword bolds" in line for line in two_result.advice)
+
+
+def test_soft_break_within_paragraph_is_flagged() -> None:
+    """Soft-wrapped Markdown prose should still flag mid-sentence bolds."""
+    rule = _build_rule()
+    text = (
+        "We must carefully review every change before\n"
+        "**carefully shipping** to production users."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"intrasentence_keyword_bold": 1}
+    assert len(result.violations) == 1
+    assert result.violations[0].match == "**carefully shipping**"
+
+
+def test_sentence_final_keyword_bold_is_flagged() -> None:
+    """Sentence-final ``**phrase.**`` is not covered by the structural rule."""
+    rule = _build_rule()
+    text = "We acted with **careful planning.**"
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"intrasentence_keyword_bold": 1}
+    assert len(result.violations) == 1
+    assert result.violations[0].match == "**careful planning.**"
+
+
+def test_label_form_with_continuation_is_ignored() -> None:
+    """``**Term:**`` followed by continuation belongs to the structural rule."""
+    rule = _build_rule()
+    text = "Earlier we noted **Important:** for the migration plan."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_paragraph_break_resets_mid_sentence_check() -> None:
+    """A bold span at the start of a new paragraph is not mid-sentence."""
+    rule = _build_rule()
+    text = (
+        "Some prior context that ends a paragraph cleanly here.\n"
+        "\n"
+        "**Background** matters for scoping the upcoming change."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_soft_break_after_sentence_terminator_is_ignored() -> None:
+    """A soft break after ``.``/``!``/``?`` starts a new sentence, not mid one."""
+    rule = _build_rule()
+    text = "We made the changes to the deploy.\n**Carefully reviewed** them later."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_inline_terminator_without_newline_is_ignored() -> None:
+    """``Foo. **Bar**`` (no newline) is a new sentence, not mid-sentence."""
+    rule = _build_rule()
+    text = "We shipped the change. **Carefully reviewed** later that day."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_trailing_spaces_before_soft_break_are_skipped() -> None:
+    """Trailing spaces before a soft break should not defeat the walk-back."""
+    rule = _build_rule()
+    # Two spaces precede the newline (a Markdown hard-break in some flavors)
+    # but we still want to detect that the prior line continues into the bold.
+    text = "We must carefully review every change before  \n**carefully shipping** to prod."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"intrasentence_keyword_bold": 1}
+    assert len(result.violations) == 1
+
+
+def test_soft_break_with_leading_whitespace_at_doc_start_is_ignored() -> None:
+    """Whitespace + a soft break at the very top of a doc is paragraph start."""
+    rule = _build_rule()
+    text = "  \n**Background** matters when scoping the upcoming change."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_period_inside_inline_code_does_not_terminate_sentence() -> None:
+    """A ``.`` inside inline code must not be mistaken for a sentence end."""
+    rule = _build_rule()
+    text = "Run `script.py.` **quickly** before midnight."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"intrasentence_keyword_bold": 1}
+    assert len(result.violations) == 1
+    assert result.violations[0].match == "**quickly**"
+
+
+def test_crlf_soft_break_after_sentence_terminator_is_ignored() -> None:
+    """Windows-style ``\\r\\n`` line endings should still detect sentence ends."""
+    rule = _build_rule()
+    text = "We made the changes to the deploy.\r\n**Carefully reviewed** them later."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
 
 
 def test_fit_returns_self_with_contrastive_samples() -> None:

--- a/tests/test_intrasentence_keyword_bold_rule.py
+++ b/tests/test_intrasentence_keyword_bold_rule.py
@@ -1,0 +1,246 @@
+"""Regression tests for intra-sentence keyword bold detection."""
+
+from slop_guard.config import DEFAULT_HYPERPARAMETERS
+from slop_guard.document import AnalysisDocument
+from slop_guard.rules.sentence import (
+    IntrasentenceKeywordBoldRule,
+    IntrasentenceKeywordBoldRuleConfig,
+)
+
+
+def _build_rule() -> IntrasentenceKeywordBoldRule:
+    """Construct the rule with the default hyperparameters."""
+    return IntrasentenceKeywordBoldRule(
+        IntrasentenceKeywordBoldRuleConfig(
+            penalty=DEFAULT_HYPERPARAMETERS.intrasentence_keyword_bold_penalty,
+            record_cap=DEFAULT_HYPERPARAMETERS.intrasentence_keyword_bold_record_cap,
+            advice_min=DEFAULT_HYPERPARAMETERS.intrasentence_keyword_bold_advice_min,
+            max_words=DEFAULT_HYPERPARAMETERS.intrasentence_keyword_bold_max_words,
+            context_window_chars=DEFAULT_HYPERPARAMETERS.context_window_chars,
+        )
+    )
+
+
+def test_flags_mid_sentence_keyword_bold() -> None:
+    """A short bold span inside flowing prose should be flagged."""
+    rule = _build_rule()
+    text = "We need to **carefully consider** every option before deciding."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"intrasentence_keyword_bold": 1}
+    assert len(result.violations) == 1
+    violation = result.violations[0]
+    assert violation.match == "**carefully consider**"
+    assert violation.start is not None and violation.end is not None
+    assert text[violation.start : violation.end] == "**carefully consider**"
+
+
+def test_flags_multiple_keyword_bolds_and_emits_summary() -> None:
+    """Multiple matches drive count_deltas and emit summary advice."""
+    rule = _build_rule()
+    text = (
+        "The plan is **highly ambitious** and the timeline is **very tight**. "
+        "It also requires **strong alignment** across teams."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"intrasentence_keyword_bold": 3}
+    assert any("mid-sentence keyword bolds" in line for line in result.advice)
+
+
+def test_record_cap_limits_emitted_violations() -> None:
+    """Violations are capped at record_cap even when more matches exist."""
+    rule = IntrasentenceKeywordBoldRule(
+        IntrasentenceKeywordBoldRuleConfig(
+            penalty=-2,
+            record_cap=2,
+            advice_min=10,
+            max_words=5,
+            context_window_chars=60,
+        )
+    )
+    text = (
+        "Use **fast paths** for **hot loops** and **cold caches**, "
+        "and add **fresh metrics** for **new dashboards**."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"intrasentence_keyword_bold": 2}
+    assert len(result.violations) == 2
+
+
+def test_label_form_at_line_start_is_ignored() -> None:
+    """Lead-in ``**Term:**`` is covered by the structural rule."""
+    rule = _build_rule()
+    text = "**Problem:** the API is slow under load."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+    assert result.count_deltas == {}
+
+
+def test_label_form_anywhere_is_ignored() -> None:
+    """``**Term:**`` forms are excluded even when not at the line start."""
+    rule = _build_rule()
+    text = "Earlier we added **Note:** to the doc without flagging it."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_bold_at_line_start_without_label_punctuation_is_ignored() -> None:
+    """Bold spans beginning a line are not mid-sentence emphasis."""
+    rule = _build_rule()
+    text = "**Background** matters when scoping the change."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_bullet_line_bold_is_ignored() -> None:
+    """Bold inside bullet lines is covered by the bold-term-bullet rule."""
+    rule = _build_rule()
+    text = "- **glossary term** with a definition that follows it."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_numbered_list_bold_is_ignored() -> None:
+    """Bold inside numbered list items is covered by other rules."""
+    rule = _build_rule()
+    text = "1. **first step** which we always perform first."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_heading_with_bold_is_ignored() -> None:
+    """Bold inside Markdown headings is typographic, not slop."""
+    rule = _build_rule()
+    text = "## The **important** section heading"
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_blockquote_bold_is_ignored() -> None:
+    """Bold inside blockquoted citations is not flagged."""
+    rule = _build_rule()
+    text = "> The author argues that this is **deeply significant** evidence."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_numeric_only_bold_is_ignored() -> None:
+    """Numeric data emphasis like ``**42%**`` or ``**$1.2M**`` is not slop."""
+    rule = _build_rule()
+    text = "Revenue grew by **42%** and total ARR reached **$1.2M** for the quarter."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_bold_inside_inline_code_is_ignored() -> None:
+    """Bold markers inside inline code spans should not be matched."""
+    rule = _build_rule()
+    text = "Use the `**bold**` syntax to emphasize text in Markdown."
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_bold_inside_fenced_code_block_is_ignored() -> None:
+    """Bold markers inside fenced code blocks should not be matched."""
+    rule = _build_rule()
+    text = (
+        "Run the snippet below.\n"
+        "```python\n"
+        'print("**carefully consider**")\n'
+        "```\n"
+        "Then review the output."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_bold_exceeding_max_words_is_ignored() -> None:
+    """Long bold spans (full sentences or callouts) are out of scope."""
+    rule = _build_rule()
+    text = (
+        "Earlier this week we noticed that "
+        "**the pipeline drops every retried message after a partial outage** "
+        "and we are still investigating."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+
+
+def test_advice_min_threshold_emits_summary_only_when_met() -> None:
+    """Summary advice fires only when match count >= advice_min."""
+    rule = IntrasentenceKeywordBoldRule(
+        IntrasentenceKeywordBoldRuleConfig(
+            penalty=-2,
+            record_cap=10,
+            advice_min=2,
+            max_words=5,
+            context_window_chars=60,
+        )
+    )
+    one_match_text = "We must **carefully plan** the rollout."
+    two_match_text = (
+        "We must **carefully plan** the rollout and **closely monitor** the metrics."
+    )
+
+    one_result = rule.forward(AnalysisDocument.from_text(one_match_text))
+    two_result = rule.forward(AnalysisDocument.from_text(two_match_text))
+
+    assert not any("mid-sentence keyword bolds" in line for line in one_result.advice)
+    assert any("mid-sentence keyword bolds" in line for line in two_result.advice)
+
+
+def test_fit_returns_self_with_contrastive_samples() -> None:
+    """Contrastive fitting should return the same rule instance."""
+    rule = _build_rule()
+    samples = [
+        "We must **carefully plan** every release before shipping it to users.",
+        "The deploy completed without any last-minute escalations or drama.",
+    ]
+    labels = [1, 0]
+
+    fitted = rule.fit(samples, labels)
+
+    assert fitted is rule
+    assert isinstance(fitted.config, IntrasentenceKeywordBoldRuleConfig)
+    assert (
+        fitted.config.max_words
+        == DEFAULT_HYPERPARAMETERS.intrasentence_keyword_bold_max_words
+    )
+
+
+def test_fit_with_empty_positive_samples_keeps_config() -> None:
+    """Fitting with no positive samples should leave config untouched."""
+    rule = _build_rule()
+    original_config = rule.config
+
+    fitted = rule.fit([], None)
+
+    assert fitted is rule
+    assert fitted.config == original_config


### PR DESCRIPTION
## Description

Adds `IntrasentenceKeywordBoldRule`, a sentence-level rule that flags short Markdown bold spans appearing mid-sentence as keyword emphasis. The rule lives at `src/slop_guard/rules/sentence/intrasentence_keyword_bold.py`, registers in the default pipeline catalog between `contrast_pair` and `setup_resolution`, and ships four tunable hyperparameters (`penalty`, `record_cap`, `advice_min`, `max_words`) wired through `default.jsonl` and `config.py`.

## Why?

Random mid-sentence bold is a common LLM tic. Models insert `**emphasis**` around arbitrary words or short phrases in flowing prose, mimicking glossary formatting where none is warranted. Existing rules partially cover the formatting family: `BoldTermBulletRunRule` handles `- **term**` bullet entries, and `StructuralPatternRule._BOLD_HEADER_RE` handles `**Header:**` label forms with trailing content. Neither catches `**emphasis**` tucked inside a regular prose sentence. This rule fills that gap while deferring to the existing rules for their respective shapes.

## Usage / Demonstration

Running `sg` on a file with mid-sentence bold now flags the span:

```markdown
We need to **carefully consider** every option before shipping.
```

```
intrasentence_keyword_bold: **carefully consider**
  Drop the mid-sentence bold around '**carefully consider**' — use plain prose instead of keyword emphasis.
```

The rule skips patterns already covered elsewhere or irrelevant to prose:

```markdown
**Note:** lead-in at line start              # label form, excluded
- **term** in a bullet list                  # bullet, excluded
## **Heading** content                       # Markdown heading, excluded
> quoted **strong claim** from a source      # blockquote, excluded
Revenue grew **42%** quarter over quarter    # numeric data, excluded
The **pipeline drops every retried message after a partial outage**.  # too long, excluded
```

The `max_words` hyperparameter (default 5) bounds the inner text so longer callouts stay out of scope.

## Verification

- `make check` passes locally: format, lint (ruff), typecheck (ty), 171 tests green, coverage 81.65%
- Added `tests/test_intrasentence_keyword_bold_rule.py` with 17 tests covering detection, every exclusion branch, `record_cap` limits, `advice_min` summary advice, and both `_fit` paths (contrastive and empty positives)
- The parametrized framework test in `tests/test_rule_framework.py` validated that the rule's `example_violations()` trigger and `example_non_violations()` do not
- PR description self-linted with `sg`

## Issues

None tracked.