### PR TITLE
Fix Pages deploy when docs content is unchanged

### DIFF
--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -315,9 +315,71 @@ def test_deploy_site_wraps_build_with_mike_deploy(
             True,
             "symlink",
             None,
-            {"branch": "gh-pages", "deploy_prefix": "docs"},
+            {"branch": "gh-pages", "allow_empty": True, "deploy_prefix": "docs"},
         )
     ]
+
+
+def test_deploy_site_allows_empty_commits_when_docs_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deployment should succeed when the built site matches the previous deploy.
+
+    Mike's deploy context manager raises ``GitEmptyCommit`` by default when the
+    rebuilt site is bit-identical to the last deploy — this happens on main
+    pushes that don't touch docs content. Passing ``allow_empty=True`` keeps
+    the workflow idempotent so code-only merges do not fail the Pages job.
+    """
+    config_path = tmp_path / "zensical.toml"
+    captured_kwargs: dict[str, object] = {}
+
+    @contextlib.contextmanager
+    def fake_deploy(*_args: object, **kwargs: object):
+        captured_kwargs.update(kwargs)
+        yield
+
+    fake_commands = types.SimpleNamespace(
+        AliasType=types.SimpleNamespace(symlink="symlink"),
+        deploy=fake_deploy,
+    )
+    fake_git_utils = types.SimpleNamespace(
+        update_from_upstream=lambda remote, branch: None,
+        push_branch=lambda remote, branch: None,
+    )
+    monkeypatch.setattr(
+        docs_site.importlib,
+        "import_module",
+        lambda name: {
+            "mike.commands": fake_commands,
+            "mike.git_utils": fake_git_utils,
+        }[name],
+    )
+    monkeypatch.setattr(docs_site, "resolve_config_file", lambda _: config_path)
+    monkeypatch.setattr(
+        docs_site,
+        "_load_docs_layout",
+        lambda _: (tmp_path / "docs", tmp_path / "site", {"site_dir": "site"}),
+    )
+    monkeypatch.setattr(
+        docs_site,
+        "build_site",
+        lambda config_file, docs_version: (tmp_path / "site" / "guide.md",),
+    )
+
+    docs_site.deploy_site(
+        None,
+        "dev",
+        (),
+        "dev (main)",
+        False,
+        "gh-pages",
+        "origin",
+        True,
+        "docs",
+    )
+
+    assert captured_kwargs["allow_empty"] is True
 
 
 def test_main_dispatches_build_command(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/docs_site.py
+++ b/tools/docs_site.py
@@ -184,6 +184,7 @@ def deploy_site(
         mike_commands.AliasType.symlink,
         None,
         branch=branch,
+        allow_empty=True,
         deploy_prefix=deploy_prefix,
     ):
         build_site(str(resolved_config), docs_version=version)


### PR DESCRIPTION
## Description

Pass `allow_empty=True` to `mike.commands.deploy` inside `tools/docs_site.py` so the Pages workflow stays idempotent on main pushes that do not touch documentation content. Added a regression test that asserts the kwarg is forwarded to mike.

## Why?

The Pages workflow on [run 24118077385](https://github.com/eric-tramel/slop-guard/actions/runs/24118077385) failed when #113 (rule-only change) landed on main:

```
mike.git_utils.GitEmptyCommit: nothing changed in commit
```

Mike's `deploy()` context manager wraps a `git_utils.Commit(..., allow_empty=False)` call. When the rebuilt site is bit-identical to the previous deploy of the same version (which is the norm for main pushes that do not touch `docs/`), the final commit is empty and mike raises. Every main push that does not change docs content would fail Pages — this is the expected steady-state, not an edge case. Passing `allow_empty=True` leaves an empty marker commit on `gh-pages` each time the deploy runs, matching the existing `git commit --allow-empty` pattern already used by the `Prepare gh-pages branch` workflow step.

## Usage / Demonstration

`mike.commands.deploy` exposes the kwarg directly:

```
(cfg, version, title=None, aliases=[], update_aliases=False,
 alias_type=<AliasType.symlink: 1>, template=None, *, branch='gh-pages',
 message=None, allow_empty=False, deploy_prefix='', set_props=[])
```

The diff:

```python
with mike_commands.deploy(
    config,
    version,
    title,
    list(aliases),
    update_aliases,
    mike_commands.AliasType.symlink,
    None,
    branch=branch,
    allow_empty=True,   # <-- added
    deploy_prefix=deploy_prefix,
):
    build_site(str(resolved_config), docs_version=version)
```

## Verification

- `uv run pytest tests/test_docs_site.py -q` — 14 passed, including the new `test_deploy_site_allows_empty_commits_when_docs_unchanged`.
- `make check` — formatting, lint, type, and the full 182-test suite pass at 81.77% coverage.

## Issues

None referenced.