### PR TITLE
Add a generated rule-library section to the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ UV_RUN ?= $(UV) run --group dev
 UV_DOCS_RUN ?= $(UV) run --group docs
 PACKAGE ?= slop_guard
 
-.PHONY: help sync fix format format-check lint typecheck test coverage check docs-serve docs-build docs-check build verify-wheel clean
+.PHONY: help sync fix format format-check lint typecheck test coverage check docs-rules docs-serve docs-build docs-check build verify-wheel clean
 
 help:
 	@printf "Available targets:\n"
@@ -18,6 +18,7 @@ help:
 	@printf "  make test          Run the pytest suite\n"
 	@printf "  make coverage      Run pytest with coverage enforcement\n"
 	@printf "  make check         Run formatting, lint, type, and coverage checks\n"
+	@printf "  make docs-rules    Regenerate the rule library page from the rule catalog\n"
 	@printf "  make docs-serve    Preview the Zensical docs locally\n"
 	@printf "  make docs-build    Build the Zensical docs site\n"
 	@printf "  make docs-check    Build docs and lint README/docs prose with slop-guard\n"
@@ -52,14 +53,17 @@ coverage:
 
 check: format-check lint typecheck coverage
 
-docs-serve:
+docs-rules:
+	$(UV_DOCS_RUN) python -m tools.docs_rules
+
+docs-serve: docs-rules
 	$(UV_DOCS_RUN) zensical serve
 
-docs-build:
+docs-build: docs-rules
 	$(UV_DOCS_RUN) python -m tools.docs_site build
 
 docs-check: docs-build
-	$(UV_DOCS_RUN) sg -t 60 README.md $$(find docs -type f -name '*.md' | sort)
+	$(UV_DOCS_RUN) sg -t 60 README.md $$(find docs -type f -name '*.md' -not -path 'docs/rules/*' | sort)
 
 build:
 	$(UV) build

--- a/docs/rules/ai-disclosure.md
+++ b/docs/rules/ai-disclosure.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: AI Disclosure
+description: Detect direct AI self-disclosure statements.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">AI Disclosure</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/ai_disclosure.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect direct AI self-disclosure statements.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>AIDisclosureRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>ai_disclosure</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>ai_disclosure</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"As an AI language model, I cannot browse the web."</code></td><td class="sg-behavior__why">Explicitly discloses model identity and capability limits.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"I am just an AI, so I do not have personal experience."</code></td><td class="sg-behavior__why">First-person model disclaimer breaks authorial voice.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The report uses only the provided dataset."</code></td><td class="sg-behavior__why">States scope directly without AI identity disclosure.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"I do not have evidence for that claim."</code></td><td class="sg-behavior__why">Epistemic limitation without model-specific boilerplate.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+High; disclosure phrases are strong and explicit AI-origin signals.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-10</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/blockquote-density.md
+++ b/docs/rules/blockquote-density.md
@@ -1,0 +1,57 @@
+---
+icon: lucide/shield-check
+title: Blockquote Density
+description: Detect excessive thesis-style blockquote usage.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--paragraph">
+  <div class="sg-rule-page__eyebrow">PARAGRAPH</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Blockquote Density</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/paragraph/blockquote_density.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect excessive thesis-style blockquote usage.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>BlockquoteDensityRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>structural</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>blockquote_density</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Multiple consecutive lines starting with "&gt;" for key arguments.</code></td><td class="sg-behavior__why">Heavy quote styling replaces integrated prose argumentation.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Repeated pull-quote sections throughout a short document.</code></td><td class="sg-behavior__why">Presentation style becomes formulaic.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">One short quotation used to cite a source.</code></td><td class="sg-behavior__why">Quote usage is limited and justified.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Code blocks and normal paragraphs without blockquote overuse.</code></td><td class="sg-behavior__why">Structural emphasis remains balanced.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium; usually indicates a style issue rather than factual error.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">cap</span><span class="sg-defaults__value">4</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">free_lines</span><span class="sg-defaults__value">2</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_lines</span><span class="sg-defaults__value">3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty_step</span><span class="sg-defaults__value">-3</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/bold-term-bullet-run.md
+++ b/docs/rules/bold-term-bullet-run.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: Bold Term Bullet Run
+description: Detect runs of bullets that start with bold terms.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--paragraph">
+  <div class="sg-rule-page__eyebrow">PARAGRAPH</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Bold Term Bullet Run</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/paragraph/bold_term_bullet_run.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect runs of bullets that start with bold terms.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>BoldTermBulletRunRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>structural</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>bold_bullet_list</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"- <strong>Reliability</strong> ...\n- <strong>Scalability</strong> ...\n- <strong>Security</strong> ..."</code></td><td class="sg-behavior__why">Consecutive bold-term bullets create rigid templated structure.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Numbered items where each starts with a bold label.</code></td><td class="sg-behavior__why">Repetitive lead-term pattern dominates the section.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">A short list with plain bullet text and no bold lead labels.</code></td><td class="sg-behavior__why">List exists without the specific template shape.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Paragraph text with occasional inline bold for emphasis.</code></td><td class="sg-behavior__why">Bold usage is not tied to repetitive bullet starts.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium to high when long runs appear in the same section.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_run_length</span><span class="sg-defaults__value">3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/bullet-density.md
+++ b/docs/rules/bullet-density.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: Bullet Density
+description: Detect bullet-heavy document formatting.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--paragraph">
+  <div class="sg-rule-page__eyebrow">PARAGRAPH</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Bullet Density</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/paragraph/bullet_density.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect bullet-heavy document formatting.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>BulletDensityRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>structural</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>bullet_density</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">A section where most lines begin with "-", "*", or numbered bullets.</code></td><td class="sg-behavior__why">High bullet ratio indicates list dominance.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">A long checklist with minimal paragraph text.</code></td><td class="sg-behavior__why">Formatting overwhelms narrative flow.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">One short bullet list embedded in otherwise normal prose.</code></td><td class="sg-behavior__why">Bullets are used sparingly for clarity.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Paragraph-only explanatory text.</code></td><td class="sg-behavior__why">No list dominance.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium to high depending on how much of the passage is list-form.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-8</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">ratio_threshold</span><span class="sg-defaults__value">0.4</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/closing-aphorism.md
+++ b/docs/rules/closing-aphorism.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Closing Aphorism
+description: Detect moralizing or generalizing closing sentences.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Closing Aphorism</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/closing_aphorism.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect moralizing or generalizing closing sentences.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ClosingAphorismRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>closing_aphorism</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>closing_aphorism</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Ultimately, it is our choices that define the system we build."</code></td><td class="sg-behavior__why">Abstract generalization that wraps up abstractly with "ultimately".</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"That's the real challenge in any distributed system."</code></td><td class="sg-behavior__why">"That's the X" closing flourish.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The build finished in 4.2 seconds."</code></td><td class="sg-behavior__why">Specific and concrete - no moral framing.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"We shipped it on Friday."</code></td><td class="sg-behavior__why">Concrete action, not an abstraction.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low; fires at most once per passage on the closing sentence only.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_sentences</span><span class="sg-defaults__value">4</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-4</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/SinatrasC"><img class="sg-contrib__avatar" src="https://github.com/SinatrasC.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@SinatrasC</span></a>
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/colon-density.md
+++ b/docs/rules/colon-density.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Colon Density
+description: Detect elaboration-colon overuse in prose passages.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Colon Density</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/colon_density.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect elaboration-colon overuse in prose passages.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ColonDensityRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>colon_density</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>colon_density</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Key point: we should retry: then back off: then log."</code></td><td class="sg-behavior__why">Multiple prose colons create a formulaic explanatory cadence.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Repeated mid-sentence "X: y..." patterns throughout one passage.</code></td><td class="sg-behavior__why">Elaboration punctuation becomes excessive.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"https://example.com:443" and JSON snippets in code fences.</code></td><td class="sg-behavior__why">Technical colons are excluded from scoring logic.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Occasional colon in a heading-like sentence.</code></td><td class="sg-behavior__why">Limited use remains within normal prose style.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low to medium; punctuation style signal that compounds with others.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">density_threshold</span><span class="sg-defaults__value">1.5</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">words_basis</span><span class="sg-defaults__value">150.0</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/contrast-pair.md
+++ b/docs/rules/contrast-pair.md
@@ -1,0 +1,61 @@
+---
+icon: lucide/shield-check
+title: Contrast Pair
+description: Detect repeated contrast constructions that stage a binary opposition.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Contrast Pair</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/contrast_pair.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect repeated contrast constructions that stage a binary opposition.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ContrastPairRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>contrast_pair</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>contrast_pairs</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"This is focus, not frenzy."</code></td><td class="sg-behavior__why">Uses the targeted "A, not B" shape.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"The platform is not only fast but also reliable."</code></td><td class="sg-behavior__why">Uses the staged "not only X but Y" frame.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"This approach prioritizes focus over speed."</code></td><td class="sg-behavior__why">Contrast exists, but not in the repetitive pattern form.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The design reduces complexity while improving clarity."</code></td><td class="sg-behavior__why">Balanced comparison without slogan-like structure.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low per instance, medium when repeated frequently in one passage.
+
+## Notes
+
+Detection is purely pattern-based — legitimate contrasts may still be flagged when density exceeds the configured threshold. Adjust `advice_min` to tune when summary advice appears.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">advice_min</span><span class="sg-defaults__value">2</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-1</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">record_cap</span><span class="sg-defaults__value">5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/copula-chain.md
+++ b/docs/rules/copula-chain.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: Copula Chain
+description: Detect high copula-sentence density - an encyclopedic AI chain pattern.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Copula Chain</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/copula_chain.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect high copula-sentence density - an encyclopedic AI chain pattern.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>CopulaChainRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>copula_chain</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>copula_chain</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Python is a language. Lists are mutable. Dicts are mappings. Sets are</code></td><td class="sg-behavior__why">unordered. Tuples are immutable. Generators are lazy." Over half the sentences open with a copula verb.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Python handles this with generators. You can use a list comprehension.</code></td><td class="sg-behavior__why">This avoids materialising the whole sequence." Copula density stays well below the threshold.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium; a single passage-level flag with concentrated penalty.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_sentences</span><span class="sg-defaults__value">6</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">threshold</span><span class="sg-defaults__value">0.5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/SinatrasC"><img class="sg-contrib__avatar" src="https://github.com/SinatrasC.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@SinatrasC</span></a>
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/em-dash-density.md
+++ b/docs/rules/em-dash-density.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Em Dash Density
+description: Detect overuse of em dashes across a passage.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Em Dash Density</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/em_dash_density.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect overuse of em dashes across a passage.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>EmDashDensityRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>em_dash</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>em_dash</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"The plan works -- quickly -- and scales -- in production."</code></td><td class="sg-behavior__why">Multiple dash interruptions in a short span.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Frequent " -- " or unicode em dash usage above configured density.</code></td><td class="sg-behavior__why">Dash rate exceeds expected prose baseline.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Occasional em dash used once for emphasis in a long section.</code></td><td class="sg-behavior__why">Stylistic punctuation remains moderate.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Punctuation primarily uses commas and periods with clear sentence flow.</code></td><td class="sg-behavior__why">No overreliance on dash cadence.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low to medium; stylistic alone, but meaningful when persistent.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">density_threshold</span><span class="sg-defaults__value">1.0</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">words_basis</span><span class="sg-defaults__value">150.0</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/extreme-sentence.md
+++ b/docs/rules/extreme-sentence.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: Extreme Sentence
+description: Detect extremely long run-on sentences.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Extreme Sentence</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/extreme_sentence.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect extremely long run-on sentences.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ExtremeSentenceRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>extreme_sentence</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>extreme_sentence</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">A single sentence of 90 words chaining subordinate clause after subordinate</code></td><td class="sg-behavior__why">clause with commas and conjunctions. The sheer length signals generated rather than drafted prose.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The update shipped on Tuesday." - short, direct sentence.</code></td><td class="sg-behavior__why"></td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">A passage where every sentence stays under 40 words.</code></td><td class="sg-behavior__why"></td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium; each hit adds structural evidence of generated text.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_words</span><span class="sg-defaults__value">140</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/SinatrasC"><img class="sg-contrib__avatar" src="https://github.com/SinatrasC.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@SinatrasC</span></a>
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/horizontal-rule-overuse.md
+++ b/docs/rules/horizontal-rule-overuse.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: Horizontal Rule Overuse
+description: Detect overuse of horizontal rule separators.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--paragraph">
+  <div class="sg-rule-page__eyebrow">PARAGRAPH</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Horizontal Rule Overuse</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/paragraph/horizontal_rule_overuse.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect overuse of horizontal rule separators.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>HorizontalRuleOveruseRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>structural</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>horizontal_rules</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Repeated "---" lines between many short sections.</code></td><td class="sg-behavior__why">Divider count exceeds reasonable editorial use.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Alternating headers and horizontal rules throughout a brief note.</code></td><td class="sg-behavior__why">Layout feels scaffolded rather than authored.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">One divider between two major sections.</code></td><td class="sg-behavior__why">Limited structural use is acceptable.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Sectioning done with headings and paragraph transitions only.</code></td><td class="sg-behavior__why">No excessive visual separators.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low to medium; mostly a formatting signal unless heavily repeated.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_count</span><span class="sg-defaults__value">4</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-3</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -1,0 +1,183 @@
+---
+icon: lucide/list-checks
+title: Rule library
+description: Catalog of the rules that slop-guard runs on every check.
+---
+
+# Rule library
+
+`slop-guard` ships a pipeline of small, independently scored rules. Each rule targets one formulaic pattern, flags the exact matching spans, and contributes a penalty toward the final score.
+
+The default pipeline runs **24 rules** across four scopes. Open a card to read the full rule page, including example violations, default thresholds, and a link to the source file.
+
+## Word rules
+
+Single-token checks. These are the cheapest rules and fire on individual AI-associated words.
+
+<div class="sg-rule-grid">
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="slop-word.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Slop Word</span></div>
+    <p class="sg-rule-card__summary">Detect overused AI-associated slop words.</p>
+  </a>
+</div>
+</div>
+
+## Sentence rules
+
+One sentence at a time. Catches canned phrases, disclosures, tone markers, and templated pivots.
+
+<div class="sg-rule-grid">
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="slop-phrase.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Slop Phrase</span></div>
+    <p class="sg-rule-card__summary">Detect stock slop phrases and transition templates.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="tone-marker.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Tone Marker</span></div>
+    <p class="sg-rule-card__summary">Detect AI-style tone markers and opener tells.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="weasel-phrase.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Weasel Phrase</span></div>
+    <p class="sg-rule-card__summary">Detect unattributed weasel phrases.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="ai-disclosure.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">AI Disclosure</span></div>
+    <p class="sg-rule-card__summary">Detect direct AI self-disclosure statements.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="placeholder.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Placeholder</span></div>
+    <p class="sg-rule-card__summary">Detect unfinished placeholder markers.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="contrast-pair.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Contrast Pair</span></div>
+    <p class="sg-rule-card__summary">Detect repeated contrast constructions that stage a binary opposition.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="intrasentence-keyword-bold.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Intrasentence Keyword Bold</span></div>
+    <p class="sg-rule-card__summary">Detect short, mid-sentence keyword bold spans (LLM emphasis tic).</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="setup-resolution.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Setup Resolution</span></div>
+    <p class="sg-rule-card__summary">Detect setup-resolution rhetorical flips.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="pithy-fragment.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Pithy Fragment</span></div>
+    <p class="sg-rule-card__summary">Detect short evaluative pivot fragments.</p>
+  </a>
+</div>
+</div>
+
+## Paragraph rules
+
+Adjacent-line structure. Catches bullet runs, blockquotes, horizontal rules, and listicle layouts.
+
+<div class="sg-rule-grid">
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="structural-pattern.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Structural Pattern</span></div>
+    <p class="sg-rule-card__summary">Detect listicle-like structural patterns in paragraphs.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="bullet-density.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Bullet Density</span></div>
+    <p class="sg-rule-card__summary">Detect bullet-heavy document formatting.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="blockquote-density.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Blockquote Density</span></div>
+    <p class="sg-rule-card__summary">Detect excessive thesis-style blockquote usage.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="bold-term-bullet-run.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Bold Term Bullet Run</span></div>
+    <p class="sg-rule-card__summary">Detect runs of bullets that start with bold terms.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="horizontal-rule-overuse.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Horizontal Rule Overuse</span></div>
+    <p class="sg-rule-card__summary">Detect overuse of horizontal rule separators.</p>
+  </a>
+</div>
+</div>
+
+## Passage rules
+
+Whole-document signals. Catches rhythm, density, and repetition across the full text.
+
+<div class="sg-rule-grid">
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="rhythm.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Rhythm</span></div>
+    <p class="sg-rule-card__summary">Detect monotonous sentence-length rhythm.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="em-dash-density.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Em Dash Density</span></div>
+    <p class="sg-rule-card__summary">Detect overuse of em dashes across a passage.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="colon-density.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Colon Density</span></div>
+    <p class="sg-rule-card__summary">Detect elaboration-colon overuse in prose passages.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="phrase-reuse.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Phrase Reuse</span></div>
+    <p class="sg-rule-card__summary">Detect repeated long n-gram phrase reuse.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="copula-chain.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Copula Chain</span></div>
+    <p class="sg-rule-card__summary">Detect high copula-sentence density - an encyclopedic AI chain pattern.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="extreme-sentence.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Extreme Sentence</span></div>
+    <p class="sg-rule-card__summary">Detect extremely long run-on sentences.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="closing-aphorism.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Closing Aphorism</span></div>
+    <p class="sg-rule-card__summary">Detect moralizing or generalizing closing sentences.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="paragraph-balance.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Paragraph Balance</span></div>
+    <p class="sg-rule-card__summary">Detect suspiciously uniform paragraph lengths.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="paragraph-cv.md">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Paragraph CV</span></div>
+    <p class="sg-rule-card__summary">Detect suspiciously uniform paragraph lengths.</p>
+  </a>
+</div>
+</div>

--- a/docs/rules/intrasentence-keyword-bold.md
+++ b/docs/rules/intrasentence-keyword-bold.md
@@ -1,0 +1,59 @@
+---
+icon: lucide/shield-check
+title: Intrasentence Keyword Bold
+description: Detect short, mid-sentence keyword bold spans (LLM emphasis tic).
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Intrasentence Keyword Bold</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/intrasentence_keyword_bold.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect short, mid-sentence keyword bold spans (LLM emphasis tic).</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>IntrasentenceKeywordBoldRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>intrasentence_keyword_bold</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>intrasentence_keyword_bold</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"We need to <strong>carefully consider</strong> all the options before deciding."</code></td><td class="sg-behavior__why">Mid-sentence bold span used as arbitrary keyword emphasis.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"The system must remain <strong>highly available</strong> during peak hours."</code></td><td class="sg-behavior__why">Two-word emphasis inserted into otherwise normal prose.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"<strong>Note:</strong> make sure to back up your data first."</code></td><td class="sg-behavior__why">Bold acts as a labeled lead-in at the start of the line.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"## A section heading without inline emphasis"</code></td><td class="sg-behavior__why">Markdown heading line with no inline bold.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The release shipped on schedule and the team celebrated."</code></td><td class="sg-behavior__why">Plain prose without any bold formatting.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low per instance, medium when repeated frequently in one passage.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">advice_min</span><span class="sg-defaults__value">3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">max_words</span><span class="sg-defaults__value">5</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">record_cap</span><span class="sg-defaults__value">5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/chris-alexiuk"><img class="sg-contrib__avatar" src="https://github.com/chris-alexiuk.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@chris-alexiuk</span></a>
+</div>
+
+</div>

--- a/docs/rules/paragraph-balance.md
+++ b/docs/rules/paragraph-balance.md
@@ -1,0 +1,59 @@
+---
+icon: lucide/shield-check
+title: Paragraph Balance
+description: Detect suspiciously uniform paragraph lengths.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Paragraph Balance</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/paragraph_rhythm.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect suspiciously uniform paragraph lengths.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ParagraphBalanceRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>paragraph_balance</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>paragraph_balance</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">A multi-paragraph essay where every paragraph is 40-50 words.</code></td><td class="sg-behavior__why">Both rules would flag the near-identical lengths.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">A passage with one two-sentence paragraph and one eight-sentence sprawl.</code></td><td class="sg-behavior__why">The high length variance passes both rules cleanly.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low to medium; stronger when combined with other rhythm signals.
+
+## Two complementary rules are provided
+
+ParagraphBalanceRule  -  fires when the shortest body paragraph is more than a configured fraction of the longest (min/max ratio too high). ParagraphCVRule  -  fires when the coefficient of variation of all paragraph word-counts falls below a threshold (low spread = formulaic rhythm).
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">balance_threshold</span><span class="sg-defaults__value">0.7</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_body_paragraphs</span><span class="sg-defaults__value">3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-6</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/SinatrasC"><img class="sg-contrib__avatar" src="https://github.com/SinatrasC.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@SinatrasC</span></a>
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/paragraph-cv.md
+++ b/docs/rules/paragraph-cv.md
@@ -1,0 +1,59 @@
+---
+icon: lucide/shield-check
+title: Paragraph CV
+description: Detect suspiciously uniform paragraph lengths.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Paragraph CV</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/paragraph_rhythm.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect suspiciously uniform paragraph lengths.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ParagraphCVRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>paragraph_cv</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>paragraph_cv</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">A multi-paragraph essay where every paragraph is 40-50 words.</code></td><td class="sg-behavior__why">Both rules would flag the near-identical lengths.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">A passage with one two-sentence paragraph and one eight-sentence sprawl.</code></td><td class="sg-behavior__why">The high length variance passes both rules cleanly.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low to medium; stronger when combined with other rhythm signals.
+
+## Two complementary rules are provided
+
+ParagraphBalanceRule  -  fires when the shortest body paragraph is more than a configured fraction of the longest (min/max ratio too high). ParagraphCVRule  -  fires when the coefficient of variation of all paragraph word-counts falls below a threshold (low spread = formulaic rhythm).
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">cv_threshold</span><span class="sg-defaults__value">0.45</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_paragraphs</span><span class="sg-defaults__value">5</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-1</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/SinatrasC"><img class="sg-contrib__avatar" src="https://github.com/SinatrasC.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@SinatrasC</span></a>
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/phrase-reuse.md
+++ b/docs/rules/phrase-reuse.md
@@ -1,0 +1,58 @@
+---
+icon: lucide/shield-check
+title: Phrase Reuse
+description: Detect repeated long n-gram phrase reuse.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Phrase Reuse</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/phrase_reuse.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect repeated long n-gram phrase reuse.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>PhraseReuseRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>phrase_reuse</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>phrase_reuse</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Repeating "at the end of the day" many times in one document.</code></td><td class="sg-behavior__why">Same phrase recurs instead of varied expression.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Reusing a 4-8 word clause across multiple paragraphs.</code></td><td class="sg-behavior__why">Long repeated n-grams suggest copy-pattern generation.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Repeating short stopword-heavy fragments like "in the end".</code></td><td class="sg-behavior__why">Common function phrases are filtered or suppressed.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Using related ideas with different wording across sections.</code></td><td class="sg-behavior__why">Semantic repetition without lexical cloning is acceptable.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium to high; repeated long phrases are strong formulaicity signals.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-1</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">record_cap</span><span class="sg-defaults__value">5</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">repeated_ngram_max_n</span><span class="sg-defaults__value">8</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">repeated_ngram_min_count</span><span class="sg-defaults__value">3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">repeated_ngram_min_n</span><span class="sg-defaults__value">4</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/pithy-fragment.md
+++ b/docs/rules/pithy-fragment.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Pithy Fragment
+description: Detect short evaluative pivot fragments.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Pithy Fragment</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/pithy_fragment.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect short evaluative pivot fragments.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>PithyFragmentRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>pithy_fragment</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>pithy_fragment</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Simple, but powerful."</code></td><td class="sg-behavior__why">Short evaluative fragment with pivot conjunction.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Fast, yet reliable."</code></td><td class="sg-behavior__why">Compact slogan-like pivot pattern.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The service is simple to run but expensive at peak load."</code></td><td class="sg-behavior__why">Full sentence with concrete tradeoff detail.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"It is fast and reliable in this benchmark."</code></td><td class="sg-behavior__why">Plain claim without fragment-style punch line.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low to medium; mostly stylistic alone, stronger when clustered.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">max_sentence_words</span><span class="sg-defaults__value">6</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">record_cap</span><span class="sg-defaults__value">3</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/placeholder.md
+++ b/docs/rules/placeholder.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: Placeholder
+description: Detect unfinished placeholder markers.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Placeholder</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/placeholder.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect unfinished placeholder markers.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>PlaceholderRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>placeholder</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>placeholder</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"[insert source citation]"</code></td><td class="sg-behavior__why">Placeholder was left unresolved in final prose.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Contact: [your email here]"</code></td><td class="sg-behavior__why">Template token is present instead of real content.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Contact: security@example.com"</code></td><td class="sg-behavior__why">Real value is present and complete.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The appendix lists all citations."</code></td><td class="sg-behavior__why">No unresolved placeholder syntax.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+High for publication quality; placeholders are explicit unfinished content and should generally be fixed before release.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/rhythm.md
+++ b/docs/rules/rhythm.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Rhythm
+description: Detect monotonous sentence-length rhythm.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Rhythm</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/rhythm.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect monotonous sentence-length rhythm.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>RhythmRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>rhythm</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>rhythm</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">A long paragraph where nearly every sentence has similar token length.</code></td><td class="sg-behavior__why">Low variation creates flat, synthetic rhythm.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">Five to ten sentences all around the same size and pacing.</code></td><td class="sg-behavior__why">Statistical variance falls below the configured threshold.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">Mixed sentence lengths with short emphatic lines and longer explanation.</code></td><td class="sg-behavior__why">Natural rhythm diversity is present.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">A concise note with too few sentences for robust rhythm inference.</code></td><td class="sg-behavior__why">Rule does not apply when sample size is small.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium; a useful style signal that is stronger with other findings.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">cv_threshold</span><span class="sg-defaults__value">0.3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_sentences</span><span class="sg-defaults__value">5</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/setup-resolution.md
+++ b/docs/rules/setup-resolution.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Setup Resolution
+description: Detect setup-resolution rhetorical flips.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Setup Resolution</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/setup_resolution.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect setup-resolution rhetorical flips.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>SetupResolutionRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>setup_resolution</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>setup_resolution</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"This is not about tooling. It is about discipline."</code></td><td class="sg-behavior__why">Classic setup then immediate reframing resolution.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"It is not random; it is deliberate."</code></td><td class="sg-behavior__why">Same flip pattern with compressed punctuation.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The problem is tooling and team discipline."</code></td><td class="sg-behavior__why">States both ideas directly without staged reversal.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"This approach emphasizes discipline over tooling."</code></td><td class="sg-behavior__why">Comparative statement without setup-resolution cadence.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium; repeated occurrences strongly suggest formulaic generation.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">record_cap</span><span class="sg-defaults__value">5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/slop-phrase.md
+++ b/docs/rules/slop-phrase.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Slop Phrase
+description: Detect stock slop phrases and transition templates.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Slop Phrase</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/slop_phrase.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect stock slop phrases and transition templates.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>SlopPhraseRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>slop_phrase</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>slop_phrases</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"It's worth noting that reliability matters."</code></td><td class="sg-behavior__why">Uses a canned setup phrase instead of stating the claim directly.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"If you want, I can adapt this into a checklist."</code></td><td class="sg-behavior__why">Uses assistant-menu phrasing that breaks authored prose voice.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Reliability matters because retries hide partial failures."</code></td><td class="sg-behavior__why">Direct assertion with rationale and no framing template.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The next section covers deployment constraints."</code></td><td class="sg-behavior__why">Legitimate transition written in plain style.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium; each hit is a strong indicator of templated writing style.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-3</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+  <a class="sg-contrib" href="https://github.com/SinatrasC"><img class="sg-contrib__avatar" src="https://github.com/SinatrasC.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@SinatrasC</span></a>
+</div>
+
+</div>

--- a/docs/rules/slop-word.md
+++ b/docs/rules/slop-word.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Slop Word
+description: Detect overused AI-associated slop words.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--word">
+  <div class="sg-rule-page__eyebrow">WORD</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Slop Word</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/word/slop_word.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect overused AI-associated slop words.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>SlopWordRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>slop_word</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>slop_words</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"This is a crucial, groundbreaking paradigm for modern teams."</code></td><td class="sg-behavior__why">Uses stacked hype words instead of concrete claims.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"We can seamlessly leverage a robust framework to unlock outcomes."</code></td><td class="sg-behavior__why">Uses multiple stock verbs and adjectives common in template prose.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"This patch removes an O(n^2) loop in the tokenizer."</code></td><td class="sg-behavior__why">Specific technical claim with no hype vocabulary.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"P95 latency dropped from 180 ms to 95 ms after batching writes."</code></td><td class="sg-behavior__why">Concrete measurement, not promotional phrasing.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low to medium per hit; repeated hits are stronger evidence of generic language and accumulate penalty quickly.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+  <a class="sg-contrib" href="https://github.com/SinatrasC"><img class="sg-contrib__avatar" src="https://github.com/SinatrasC.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@SinatrasC</span></a>
+</div>
+
+</div>

--- a/docs/rules/structural-pattern.md
+++ b/docs/rules/structural-pattern.md
@@ -1,0 +1,61 @@
+---
+icon: lucide/shield-check
+title: Structural Pattern
+description: Detect listicle-like structural patterns in paragraphs.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--paragraph">
+  <div class="sg-rule-page__eyebrow">PARAGRAPH</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Structural Pattern</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/paragraph/structural_pattern.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect listicle-like structural patterns in paragraphs.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>StructuralPatternRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>structural</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>structural</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"<strong>Problem:</strong> ... <strong>Solution:</strong> ... <strong>Result:</strong> ..."</code></td><td class="sg-behavior__why">Repeated bold-header blocks produce rigid listicle framing.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Reliable, scalable, and maintainable."</code></td><td class="sg-behavior__why">Triadic pattern used repeatedly creates synthetic cadence.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The section opens with one heading followed by normal paragraphs."</code></td><td class="sg-behavior__why">Uses structure, but not repetitive patterning.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The system is reliable and maintainable at this workload."</code></td><td class="sg-behavior__why">Natural phrasing without triadic slogan cadence.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium to high when multiple structural signals co-occur.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">bold_header_min</span><span class="sg-defaults__value">3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">bold_header_penalty</span><span class="sg-defaults__value">-5</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">bullet_run_min</span><span class="sg-defaults__value">6</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">bullet_run_penalty</span><span class="sg-defaults__value">-3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">triadic_advice_min</span><span class="sg-defaults__value">3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">triadic_penalty</span><span class="sg-defaults__value">-1</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">triadic_record_cap</span><span class="sg-defaults__value">5</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/tone-marker.md
+++ b/docs/rules/tone-marker.md
@@ -1,0 +1,56 @@
+---
+icon: lucide/shield-check
+title: Tone Marker
+description: Detect AI-style tone markers and opener tells.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Tone Marker</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/tone_marker.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect AI-style tone markers and opener tells.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ToneMarkerRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>tone</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>tone</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Would you like me to provide a shorter version?"</code></td><td class="sg-behavior__why">Meta-conversation phrasing is an AI tell in authored prose.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Certainly, this approach works in most environments."</code></td><td class="sg-behavior__why">Formulaic opener pattern used by assistant responses.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"This approach works in most environments."</code></td><td class="sg-behavior__why">Same claim without assistant-style framing.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The failure occurred after the second retry."</code></td><td class="sg-behavior__why">Neutral narration without scripted dramatic setup.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium to high; often a strong signal of assistant-authored tone.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">sentence_opener_penalty</span><span class="sg-defaults__value">-2</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">tone_penalty</span><span class="sg-defaults__value">-3</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/rules/weasel-phrase.md
+++ b/docs/rules/weasel-phrase.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: Weasel Phrase
+description: Detect unattributed weasel phrases.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Weasel Phrase</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/weasel_phrase.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect unattributed weasel phrases.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>WeaselPhraseRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>weasel</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>weasel</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Many believe this framework is the future."</code></td><td class="sg-behavior__why">Uses anonymous consensus instead of evidence.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Studies show the feature improves trust."</code></td><td class="sg-behavior__why">Claims research support without any citation context.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"A 2024 ACM paper reports a 12 percent error reduction."</code></td><td class="sg-behavior__why">Provides concrete source context.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"We expect lower error rates based on last quarter's logs."</code></td><td class="sg-behavior__why">Owns the claim and basis directly.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium; each hit indicates weak attribution and rhetorical padding.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+</div>
+
+## Contributors
+
+<div class="sg-contributors">
+  <a class="sg-contrib" href="https://github.com/eric-tramel"><img class="sg-contrib__avatar" src="https://github.com/eric-tramel.png?size=72" alt="" loading="lazy" width="24" height="24" /><span class="sg-contrib__name">@eric-tramel</span></a>
+</div>
+
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,473 @@
+/* ---------- Slop-guard palette ---------- */
+
+:root {
+  --sg-paper:        #f6efe4;
+  --sg-paper-strong: #fffaf3;
+  --sg-paper-cool:   #eef5f1;
+  --sg-ink:          #1d271f;
+  --sg-muted:        #58645d;
+  --sg-line:         rgba(29, 39, 31, 0.12);
+
+  --sg-slop:         #c4573e;
+  --sg-slop-deep:    #8e2e1d;
+  --sg-slop-soft:    rgba(196, 87, 62, 0.14);
+  --sg-clean:        #0f706f;
+  --sg-clean-deep:   #0b5958;
+  --sg-clean-soft:   rgba(15, 112, 111, 0.14);
+  --sg-accent:       #d5a550;
+  --sg-accent-deep:  #8f6421;
+
+  /* Dark-mode variants, tuned to stay warm on a deep ink ground. */
+  --sg-paper-dark:        #f6efe4;
+  --sg-ink-dark:          #10171a;
+  --sg-ink-dark-raised:   #18211e;
+  --sg-ink-dark-lifted:   #1f2a26;
+  --sg-muted-dark:        rgba(246, 239, 228, 0.72);
+  --sg-line-dark:         rgba(246, 239, 228, 0.14);
+  --sg-slop-light:        #e48871;
+  --sg-clean-light:       #5fc7bd;
+  --sg-accent-light:      #e9ba6b;
+}
+
+/* ---------- Light scheme (default) ---------- */
+
+[data-md-color-scheme="default"] {
+  --md-default-bg-color:            var(--sg-paper);
+  --md-default-bg-color--light:     var(--sg-paper-strong);
+  --md-default-bg-color--lighter:   var(--sg-paper-strong);
+  --md-default-bg-color--lightest:  var(--sg-paper-strong);
+
+  --md-default-fg-color:            var(--sg-ink);
+  --md-default-fg-color--light:     var(--sg-muted);
+  --md-default-fg-color--lighter:   rgba(29, 39, 31, 0.46);
+  --md-default-fg-color--lightest:  rgba(29, 39, 31, 0.16);
+
+  --md-primary-fg-color:            var(--sg-clean);
+  --md-primary-fg-color--light:     #2a8a89;
+  --md-primary-fg-color--dark:      var(--sg-clean-deep);
+  --md-primary-bg-color:            var(--sg-paper-strong);
+  --md-primary-bg-color--light:     rgba(255, 250, 243, 0.78);
+
+  --md-accent-fg-color:             var(--sg-slop);
+  --md-accent-fg-color--transparent: var(--sg-slop-soft);
+  --md-accent-bg-color:             var(--sg-paper-strong);
+  --md-accent-bg-color--light:      rgba(255, 250, 243, 0.78);
+
+  --md-typeset-a-color:             var(--sg-clean);
+  --md-typeset-mark-color:          var(--sg-slop-soft);
+
+  --md-code-bg-color:               rgba(255, 250, 243, 0.92);
+  --md-code-fg-color:               var(--sg-ink);
+  --md-code-hl-color:               var(--sg-accent);
+
+  --md-footer-bg-color:             #16201b;
+  --md-footer-bg-color--dark:       #0f1714;
+}
+
+/* ---------- Dark scheme (slate) ---------- */
+
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color:            var(--sg-ink-dark);
+  --md-default-bg-color--light:     var(--sg-ink-dark-raised);
+  --md-default-bg-color--lighter:   var(--sg-ink-dark-lifted);
+  --md-default-bg-color--lightest:  #27322d;
+
+  --md-default-fg-color:            var(--sg-paper-dark);
+  --md-default-fg-color--light:     var(--sg-muted-dark);
+  --md-default-fg-color--lighter:   rgba(246, 239, 228, 0.52);
+  --md-default-fg-color--lightest:  rgba(246, 239, 228, 0.18);
+
+  --md-primary-fg-color:            var(--sg-clean-light);
+  --md-primary-fg-color--light:     #82dacf;
+  --md-primary-fg-color--dark:      #3ea79c;
+  --md-primary-bg-color:            var(--sg-ink-dark);
+  --md-primary-bg-color--light:     var(--sg-ink-dark-raised);
+
+  --md-accent-fg-color:             var(--sg-slop-light);
+  --md-accent-fg-color--transparent: rgba(228, 136, 113, 0.18);
+  --md-accent-bg-color:             var(--sg-ink-dark);
+  --md-accent-bg-color--light:      var(--sg-ink-dark-raised);
+
+  --md-typeset-a-color:             var(--sg-clean-light);
+  --md-typeset-mark-color:          rgba(228, 136, 113, 0.22);
+
+  --md-code-bg-color:               #0c1311;
+  --md-code-fg-color:               var(--sg-paper-dark);
+  --md-code-hl-color:               var(--sg-accent-light);
+
+  --md-footer-bg-color:             #0a1210;
+  --md-footer-bg-color--dark:       #060a08;
+}
+
+/* ---------- Rule page: header (eyebrow, title, source, lede) ----------
+
+   Intentionally uses em-relative sizing so the rule page inherits the
+   Material typographic scale from `.md-typeset` (same base as the nav,
+   breadcrumbs, and body prose elsewhere in the docs).
+*/
+
+.sg-rule-page__header {
+  margin: 0 0 1.35rem 0;
+}
+
+.sg-rule-page__eyebrow {
+  font-size: 0.7em;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 0.55rem;
+}
+
+[data-md-color-scheme="default"] .sg-rule-page__header--word      .sg-rule-page__eyebrow { color: var(--sg-muted); }
+[data-md-color-scheme="default"] .sg-rule-page__header--sentence  .sg-rule-page__eyebrow { color: var(--sg-slop); }
+[data-md-color-scheme="default"] .sg-rule-page__header--paragraph .sg-rule-page__eyebrow { color: var(--sg-accent-deep); }
+[data-md-color-scheme="default"] .sg-rule-page__header--passage   .sg-rule-page__eyebrow { color: var(--sg-clean); }
+
+[data-md-color-scheme="slate"] .sg-rule-page__header--word      .sg-rule-page__eyebrow { color: var(--sg-muted-dark); }
+[data-md-color-scheme="slate"] .sg-rule-page__header--sentence  .sg-rule-page__eyebrow { color: var(--sg-slop-light); }
+[data-md-color-scheme="slate"] .sg-rule-page__header--paragraph .sg-rule-page__eyebrow { color: var(--sg-accent-light); }
+[data-md-color-scheme="slate"] .sg-rule-page__header--passage   .sg-rule-page__eyebrow { color: var(--sg-clean-light); }
+
+.sg-rule-page__titlebar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem 0.9rem;
+}
+
+.md-typeset .sg-rule-page .sg-rule-page__title {
+  margin: 0;
+  font-size: 1.75em;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+.md-typeset .sg-rule-page .sg-source-chip,
+.md-typeset .sg-rule-page .sg-source-chip:visited {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.18em 0.6em;
+  font-size: 0.75em;
+  font-weight: 600;
+  border-radius: 999px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  color: var(--md-default-fg-color--light);
+  text-decoration: none !important;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+
+.md-typeset .sg-rule-page .sg-source-chip:hover {
+  color: var(--md-default-fg-color);
+  border-color: var(--md-primary-fg-color);
+}
+
+.sg-source-chip__icon { flex-shrink: 0; }
+
+.md-typeset .sg-rule-page .sg-rule-page__lede {
+  margin: 0.7rem 0 0 0;
+  font-size: 1em;
+  line-height: 1.55;
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .sg-rule-page .sg-rule-page__lede code {
+  background: var(--md-default-bg-color--light);
+  color: var(--md-default-fg-color);
+  font-size: 0.88em;
+  padding: 0.08em 0.35em;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 4px;
+}
+
+/* ---------- Rule page: three-column meta strip ---------- */
+
+.md-typeset .sg-rule-page .sg-rule-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0 0 1.8rem 0;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 12px;
+  overflow: hidden;
+  background: transparent;
+}
+
+.sg-rule-meta__item {
+  padding: 0.65rem 0.85rem 0.7rem;
+  border-right: 1px solid var(--md-default-fg-color--lightest);
+  min-width: 0;
+}
+
+.sg-rule-meta__item:last-child { border-right: 0; }
+
+.md-typeset .sg-rule-page .sg-rule-meta__item dt {
+  margin: 0 0 0.25rem 0;
+  font-size: 0.65em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .sg-rule-page .sg-rule-meta__item dd {
+  margin: 0;
+  font-family: var(--md-code-font-family, ui-monospace, monospace);
+  font-size: 0.85em;
+  color: var(--md-default-fg-color);
+  word-break: break-all;
+}
+
+.md-typeset .sg-rule-page .sg-rule-meta__item dd code {
+  background: transparent;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+@media (max-width: 640px) {
+  .md-typeset .sg-rule-page .sg-rule-meta {
+    grid-template-columns: 1fr;
+  }
+  .sg-rule-meta__item {
+    border-right: 0;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  }
+  .sg-rule-meta__item:last-child { border-bottom: 0; }
+}
+
+/* ---------- Rule page: section headings act as quiet dividers ---------- */
+
+.md-typeset .sg-rule-page h2 {
+  margin: 1.4rem 0 0.7rem 0;
+  padding: 1.1rem 0 0 0;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  font-size: 0.7em;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--light);
+}
+
+/* ---------- Rule page: behavior table ---------- */
+
+.md-typeset .sg-rule-page .sg-behavior {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 1rem 0;
+  font-size: 1em;
+  background: transparent;
+}
+
+.md-typeset .sg-rule-page .sg-behavior th,
+.md-typeset .sg-rule-page .sg-behavior td {
+  text-align: left;
+  padding: 0.55rem 0.7rem;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  vertical-align: top;
+  background: transparent;
+  line-height: 1.5;
+}
+
+.md-typeset .sg-rule-page .sg-behavior th {
+  font-size: 0.65em;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--light);
+  background: transparent;
+}
+
+.md-typeset .sg-rule-page .sg-behavior tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.sg-behavior__result { width: 6rem; }
+.sg-behavior__why    { color: var(--md-default-fg-color--light); }
+
+.sg-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.7em;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.sg-status__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.sg-status--flag { color: var(--sg-slop); }
+.sg-status--flag .sg-status__dot { background: var(--sg-slop); }
+.sg-status--pass { color: var(--sg-clean); }
+.sg-status--pass .sg-status__dot { background: var(--sg-clean); }
+
+[data-md-color-scheme="slate"] .sg-status--flag { color: var(--sg-slop-light); }
+[data-md-color-scheme="slate"] .sg-status--flag .sg-status__dot { background: var(--sg-slop-light); }
+[data-md-color-scheme="slate"] .sg-status--pass { color: var(--sg-clean-light); }
+[data-md-color-scheme="slate"] .sg-status--pass .sg-status__dot { background: var(--sg-clean-light); }
+
+.md-typeset .sg-rule-page .sg-behavior__input {
+  background: transparent;
+  padding: 0;
+  font-size: 0.9em;
+  color: var(--md-default-fg-color);
+  word-break: break-word;
+}
+
+/* ---------- Rule page: default configuration grid ---------- */
+
+.sg-defaults {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.55rem;
+  margin: 0 0 1.6rem 0;
+}
+
+.sg-defaults__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.6rem 0.8rem 0.65rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  background: transparent;
+}
+
+.sg-defaults__label {
+  font-size: 0.65em;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--md-default-fg-color--light);
+}
+
+.sg-defaults__value {
+  font-family: var(--md-code-font-family, ui-monospace, monospace);
+  font-size: 1em;
+  font-weight: 600;
+  color: var(--md-default-fg-color);
+}
+
+/* ---------- Rule page: contributors chips ---------- */
+
+.sg-contributors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 0 1rem 0;
+}
+
+.md-typeset .sg-rule-page .sg-contrib,
+.md-typeset .sg-rule-page .sg-contrib:visited {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.3rem 0.75rem 0.3rem 0.3rem;
+  border-radius: 999px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  text-decoration: none !important;
+  color: var(--md-default-fg-color);
+  transition: border-color 140ms ease, background 140ms ease;
+}
+
+.md-typeset .sg-rule-page .sg-contrib:hover {
+  border-color: var(--md-primary-fg-color);
+  background: var(--md-default-bg-color--light);
+}
+
+.sg-contrib__avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  flex-shrink: 0;
+}
+
+.sg-contrib__name {
+  font-size: 0.85em;
+  font-weight: 600;
+}
+
+/* ---------- Rule-library index card grid ---------- */
+
+.sg-rule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.9rem;
+  margin: 0.6rem 0 1.4rem 0;
+}
+
+.sg-rule-card {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 14px;
+  background: var(--md-default-bg-color--light);
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease;
+}
+
+[data-md-color-scheme="default"] .sg-rule-card {
+  box-shadow: 0 1px 2px rgba(29, 39, 31, 0.04);
+}
+
+.sg-rule-card:hover {
+  border-color: var(--md-primary-fg-color);
+  transform: translateY(-2px);
+}
+
+[data-md-color-scheme="default"] .sg-rule-card:hover {
+  background: var(--sg-paper-strong);
+  box-shadow: 0 10px 24px rgba(78, 48, 29, 0.10);
+}
+
+[data-md-color-scheme="slate"] .sg-rule-card:hover {
+  background: var(--sg-ink-dark-lifted);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.md-typeset .sg-rule-card__link,
+.md-typeset .sg-rule-card__link:visited,
+.md-typeset .sg-rule-card__link:hover,
+.md-typeset .sg-rule-card__link *,
+.md-typeset .sg-rule-card__link:hover * {
+  text-decoration: none !important;
+  border-bottom: 0 !important;
+}
+
+.md-typeset .sg-rule-card__link {
+  display: block;
+  padding: 0.85rem 1rem;
+  color: inherit;
+}
+
+.sg-rule-card__head {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-bottom: 0.35rem;
+}
+
+.sg-rule-card__title {
+  font-weight: 700;
+  font-size: 0.98rem;
+  letter-spacing: -0.01em;
+  color: var(--md-primary-fg-color);
+}
+
+.sg-rule-card__summary {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.4;
+  color: var(--md-default-fg-color--light);
+}

--- a/src/slop_guard/rules/sentence/contrast_pair.py
+++ b/src/slop_guard/rules/sentence/contrast_pair.py
@@ -17,6 +17,10 @@ Example Non-Violations:
       Balanced comparison without slogan-like structure.
 
 Severity: Low per instance, medium when repeated frequently in one passage.
+
+Notes: Detection is purely pattern-based — legitimate contrasts may still be
+flagged when density exceeds the configured threshold. Adjust `advice_min` to
+tune when summary advice appears.
 """
 
 import math

--- a/tools/docs_rules.py
+++ b/tools/docs_rules.py
@@ -1,0 +1,637 @@
+"""Generate the rule library docs — one page per rule plus an index.
+
+This helper introspects each rule class listed in
+:mod:`slop_guard.rules.catalog`, parses its module docstring for the
+common ``Objective`` / ``Example Rule Violations`` / ``Example
+Non-Violations`` / ``Severity`` sections, pulls default config values out
+of ``assets/default.jsonl``, and writes one Markdown page per rule under
+``docs/rules/`` plus an ``index.md`` overview that links to them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import inspect
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from importlib import import_module
+from importlib.resources import files
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from slop_guard.rules.base import Rule
+from slop_guard.rules.catalog import DEFAULT_RULE_PATHS
+
+RulePath: TypeAlias = str
+ConfigMap: TypeAlias = dict[str, Any]
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_OUTPUT_DIR = _REPO_ROOT / "docs" / "rules"
+_REPO_SOURCE_REPO = "eric-tramel/slop-guard"
+_REPO_SOURCE_URL = f"https://github.com/{_REPO_SOURCE_REPO}/blob/main"
+_KNOWN_SECTIONS: frozenset[str] = frozenset(
+    {
+        "_summary",
+        "Objective",
+        "Severity",
+        "Example Rule Violations",
+        "Example Non-Violations",
+    }
+)
+_BOT_LOGINS: frozenset[str] = frozenset(
+    {"web-flow", "github-actions[bot]", "dependabot[bot]"}
+)
+_GH_ICON_SVG = (
+    '<svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" '
+    'height="14" aria-hidden="true" focusable="false">'
+    '<path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 '
+    "9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-"
+    ".52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 "
+    "1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-"
+    "5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 "
+    "0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 "
+    "2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 "
+    "1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31"
+    ".21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"
+    '"/></svg>'
+)
+
+_LEVEL_ORDER: tuple[str, ...] = ("word", "sentence", "paragraph", "passage")
+_LEVEL_LABEL: dict[str, str] = {
+    "word": "Word",
+    "sentence": "Sentence",
+    "paragraph": "Paragraph",
+    "passage": "Passage",
+}
+_LEVEL_BLURB: dict[str, str] = {
+    "word": (
+        "Single-token checks. These are the cheapest rules and fire on "
+        "individual AI-associated words."
+    ),
+    "sentence": (
+        "One sentence at a time. Catches canned phrases, disclosures, tone "
+        "markers, and templated pivots."
+    ),
+    "paragraph": (
+        "Adjacent-line structure. Catches bullet runs, blockquotes, "
+        "horizontal rules, and listicle layouts."
+    ),
+    "passage": (
+        "Whole-document signals. Catches rhythm, density, and repetition "
+        "across the full text."
+    ),
+}
+_CAMEL_SPLIT_RE = re.compile(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+
+@dataclass(frozen=True)
+class Example:
+    """One parsed docstring example with its inline rationale."""
+
+    text: str
+    note: str
+
+
+@dataclass(frozen=True)
+class ExtraSection:
+    """A free-form ``Heading: body`` section lifted from a rule docstring."""
+
+    title: str
+    body: str
+
+
+@dataclass(frozen=True)
+class Contributor:
+    """A rule-file contributor resolved from ``git log`` + ``gh api``."""
+
+    login: str
+    name: str
+
+
+@dataclass(frozen=True)
+class ParsedDocstring:
+    """Structured view of a rule module's docstring sections."""
+
+    summary: str
+    objective: str
+    example_violations: tuple[Example, ...]
+    example_non_violations: tuple[Example, ...]
+    severity: str
+    extras: tuple[ExtraSection, ...]
+
+
+@dataclass(frozen=True)
+class RuleDoc:
+    """Everything the template needs to render one rule page."""
+
+    rule_type: type[Rule[Any]]
+    dotted_path: RulePath
+    source_path: Path
+    relative_source_path: Path
+    parsed: ParsedDocstring
+    defaults: ConfigMap
+    slug: str
+    title: str
+    contributors: tuple[Contributor, ...]
+
+
+def _load_default_configs() -> dict[str, ConfigMap]:
+    """Return default config dicts keyed by the fully-qualified rule path."""
+    raw_text = (
+        files("slop_guard.rules")
+        .joinpath("assets/default.jsonl")
+        .read_text(encoding="utf-8")
+    )
+    configs: dict[str, ConfigMap] = {}
+    for line in raw_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        payload = json.loads(stripped)
+        configs[payload["rule_type"]] = dict(payload["config"])
+    return configs
+
+
+def _dedent_lines(lines: list[str]) -> list[str]:
+    """Drop common leading whitespace from a block of docstring lines."""
+    stripped_for_indent = [line for line in lines if line.strip()]
+    if not stripped_for_indent:
+        return lines
+    indent = min(len(line) - len(line.lstrip(" ")) for line in stripped_for_indent)
+    return [line[indent:] if line.strip() else "" for line in lines]
+
+
+def _split_sections(docstring: str) -> dict[str, list[str]]:
+    """Split a rule docstring into labeled sections.
+
+    A section header is any zero-indent line matching ``Title: remainder``
+    where the title starts with a capital letter. Subsequent indented or
+    continuation lines accumulate under that title.
+    """
+    lines = docstring.splitlines()
+    sections: dict[str, list[str]] = {"_summary": []}
+    current = "_summary"
+    header_pattern = re.compile(r"^([A-Z][A-Za-z][A-Za-z &\-]*?):\s*(.*)$")
+    for raw_line in lines:
+        match = header_pattern.match(raw_line)
+        if match and not raw_line.startswith(" "):
+            current = match.group(1).strip()
+            remainder = match.group(2).strip()
+            sections[current] = [remainder] if remainder else []
+            continue
+        sections.setdefault(current, []).append(raw_line)
+    return sections
+
+
+def _join_paragraph(lines: list[str]) -> str:
+    """Collapse a dedented multi-line block into a single paragraph."""
+    dedented = _dedent_lines(lines)
+    cleaned = [line.strip() for line in dedented if line.strip()]
+    return " ".join(cleaned)
+
+
+def _parse_examples(lines: list[str]) -> tuple[Example, ...]:
+    """Parse ``- primary\\n  note`` example pairs into ``Example`` records."""
+    dedented = _dedent_lines(lines)
+    examples: list[tuple[str, list[str]]] = []
+    for raw_line in dedented:
+        if raw_line.startswith("- "):
+            examples.append((raw_line[2:].strip(), []))
+        elif raw_line.strip() and examples:
+            examples[-1][1].append(raw_line.strip())
+    return tuple(
+        Example(text=primary, note=" ".join(notes).strip())
+        for primary, notes in examples
+    )
+
+
+def _parse_docstring(docstring: str) -> ParsedDocstring:
+    """Parse the shared rule docstring format into structured fields."""
+    sections = _split_sections(docstring)
+    summary = _join_paragraph(sections.get("_summary", []))
+    objective = _join_paragraph(sections.get("Objective", []))
+    severity = _join_paragraph(sections.get("Severity", []))
+    example_violations: tuple[Example, ...] = ()
+    example_non_violations: tuple[Example, ...] = ()
+    extras: list[ExtraSection] = []
+    for key, lines in sections.items():
+        if key == "Example Rule Violations":
+            example_violations = _parse_examples(lines)
+        elif key == "Example Non-Violations":
+            example_non_violations = _parse_examples(lines)
+        elif key in _KNOWN_SECTIONS:
+            continue
+        else:
+            body = _join_paragraph(lines)
+            if body:
+                extras.append(ExtraSection(title=key, body=body))
+    return ParsedDocstring(
+        summary=summary,
+        objective=objective,
+        example_violations=example_violations,
+        example_non_violations=example_non_violations,
+        severity=severity,
+        extras=tuple(extras),
+    )
+
+
+def _slug(name: str) -> str:
+    """Build a stable anchor slug from any name."""
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+def _rule_title(rule_type: type[Rule[Any]]) -> str:
+    """Return a human-readable title derived from the class name."""
+    class_name = rule_type.__name__
+    trimmed = class_name[:-4] if class_name.endswith("Rule") else class_name
+    return _CAMEL_SPLIT_RE.sub(" ", trimmed)
+
+
+def _rule_slug(rule_type: type[Rule[Any]]) -> str:
+    """Return a stable unique slug derived from the class name."""
+    class_name = rule_type.__name__
+    trimmed = class_name[:-4] if class_name.endswith("Rule") else class_name
+    return _slug(_CAMEL_SPLIT_RE.sub("-", trimmed))
+
+
+_LOGIN_CACHE: dict[str, str | None] = {}
+
+
+def _resolve_github_login(commit_sha: str, email: str) -> str | None:
+    """Return the GitHub login for a commit author, cached by email."""
+    if email in _LOGIN_CACHE:
+        return _LOGIN_CACHE[email]
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"/repos/{_REPO_SOURCE_REPO}/commits/{commit_sha}",
+                "--jq",
+                ".author.login",
+            ],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        login = proc.stdout.strip() or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        login = None
+    _LOGIN_CACHE[email] = login
+    return login
+
+
+def _load_contributors(relative_path: Path) -> tuple[Contributor, ...]:
+    """Aggregate unique GitHub contributors to a source file via ``git log``."""
+    try:
+        proc = subprocess.run(
+            [
+                "git",
+                "log",
+                "--follow",
+                "--format=%an|%ae|%H",
+                "--",
+                str(relative_path),
+            ],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ()
+
+    first_seen: dict[str, tuple[str, str]] = {}
+    for line in reversed(proc.stdout.splitlines()):
+        if not line.strip():
+            continue
+        name, email, sha = line.split("|", 2)
+        first_seen.setdefault(email, (name, sha))
+
+    contributors: list[Contributor] = []
+    seen_logins: set[str] = set()
+    for email, (name, sha) in first_seen.items():
+        login = _resolve_github_login(sha, email)
+        if not login or login in _BOT_LOGINS or login in seen_logins:
+            continue
+        seen_logins.add(login)
+        contributors.append(Contributor(login=login, name=name))
+    return tuple(contributors)
+
+
+def _load_rule_doc(dotted_path: str, defaults: dict[str, ConfigMap]) -> RuleDoc:
+    """Import one rule class and gather everything needed to render it."""
+    module_name, _, class_name = dotted_path.rpartition(".")
+    module = import_module(module_name)
+    rule_type = getattr(module, class_name)
+    source_path = Path(inspect.getsourcefile(module) or module.__file__ or "")
+    relative_source_path = source_path.resolve().relative_to(_REPO_ROOT)
+    parsed = _parse_docstring(module.__doc__ or "")
+    return RuleDoc(
+        rule_type=rule_type,
+        dotted_path=dotted_path,
+        source_path=source_path,
+        relative_source_path=relative_source_path,
+        parsed=parsed,
+        defaults=defaults.get(dotted_path, {}),
+        slug=_rule_slug(rule_type),
+        title=_rule_title(rule_type),
+        contributors=_load_contributors(relative_source_path),
+    )
+
+
+def _format_inline(text: str) -> str:
+    """Escape for HTML and lift ``**bold**`` into ``<strong>`` spans."""
+    escaped = html.escape(text, quote=False)
+    return re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+
+
+def _render_header(doc: RuleDoc, summary: str, source_url: str) -> str:
+    """Render the top eyebrow + title + source chip + lede block."""
+    level = doc.rule_type.level.value
+    level_label = _LEVEL_LABEL[level].upper()
+    title = html.escape(doc.title)
+    lines = [
+        f'<header class="sg-rule-page__header sg-rule-page__header--{level}">',
+        f'  <div class="sg-rule-page__eyebrow">{level_label}</div>',
+        '  <div class="sg-rule-page__titlebar">',
+        f'    <h1 class="sg-rule-page__title">{title}</h1>',
+        f'    <a class="sg-source-chip" href="{html.escape(source_url)}">'
+        f"{_GH_ICON_SVG}<span>source</span></a>",
+        "  </div>",
+    ]
+    if summary:
+        lines.append(
+            '  <p class="sg-rule-page__lede" markdown>'
+            f"{summary}</p>"
+        )
+    lines.append("</header>")
+    return "\n".join(lines)
+
+
+def _render_meta_row(doc: RuleDoc) -> str:
+    """Render the three-column Class / Rule name / Count key strip."""
+    items = [
+        ("Class", doc.rule_type.__name__),
+        ("Rule name", doc.rule_type.name),
+        ("Count key", doc.rule_type.count_key),
+    ]
+    parts = ['<dl class="sg-rule-meta">']
+    for label, value in items:
+        parts.append(
+            '  <div class="sg-rule-meta__item">'
+            f"<dt>{html.escape(label)}</dt>"
+            f"<dd><code>{html.escape(value)}</code></dd>"
+            "</div>"
+        )
+    parts.append("</dl>")
+    return "\n".join(parts)
+
+
+def _render_behavior_table(doc: RuleDoc) -> str:
+    """Render the combined Triggers/Non-triggers table with status cells."""
+    rows: list[str] = []
+    for item in doc.parsed.example_violations:
+        rows.append(_render_behavior_row("flag", "Flag", item))
+    for item in doc.parsed.example_non_violations:
+        rows.append(_render_behavior_row("pass", "Pass", item))
+    if not rows:
+        return "_No behavior examples documented._"
+    return "\n".join(
+        [
+            '<table class="sg-behavior">',
+            "  <thead>",
+            "    <tr>"
+            '<th class="sg-behavior__th-result">Result</th>'
+            "<th>Input text</th>"
+            "<th>Why</th>"
+            "</tr>",
+            "  </thead>",
+            "  <tbody>",
+            *[f"    {row}" for row in rows],
+            "  </tbody>",
+            "</table>",
+        ]
+    )
+
+
+def _render_behavior_row(variant: str, label: str, item: Example) -> str:
+    """Render one row of the behavior table."""
+    text_html = _format_inline(item.text)
+    note_html = _format_inline(item.note) if item.note else ""
+    return (
+        f'<tr class="sg-behavior__row sg-behavior__row--{variant}">'
+        '<td class="sg-behavior__result">'
+        f'<span class="sg-status sg-status--{variant}">'
+        '<span class="sg-status__dot" aria-hidden="true"></span>'
+        f"{label}</span></td>"
+        f'<td><code class="sg-behavior__input">{text_html}</code></td>'
+        f'<td class="sg-behavior__why">{note_html}</td>'
+        "</tr>"
+    )
+
+
+def _render_defaults(defaults: ConfigMap) -> str:
+    """Render the default-configuration grid."""
+    if not defaults:
+        return "_No configurable parameters._"
+    parts = ['<div class="sg-defaults">']
+    for key in sorted(defaults):
+        value = defaults[key]
+        parts.append(
+            '  <div class="sg-defaults__item">'
+            f'<span class="sg-defaults__label">{html.escape(key)}</span>'
+            f'<span class="sg-defaults__value">{html.escape(str(value))}</span>'
+            "</div>"
+        )
+    parts.append("</div>")
+    return "\n".join(parts)
+
+
+def _render_contributors(contributors: tuple[Contributor, ...]) -> str:
+    """Render the blame-derived contributor chips."""
+    if not contributors:
+        return "_No contributors detected._"
+    parts = ['<div class="sg-contributors">']
+    for c in contributors:
+        avatar = f"https://github.com/{c.login}.png?size=72"
+        parts.append(
+            f'  <a class="sg-contrib" href="https://github.com/{c.login}">'
+            f'<img class="sg-contrib__avatar" src="{avatar}" '
+            'alt="" loading="lazy" width="24" height="24" />'
+            f'<span class="sg-contrib__name">@{c.login}</span>'
+            "</a>"
+        )
+    parts.append("</div>")
+    return "\n".join(parts)
+
+
+def _group_by_level(docs: list[RuleDoc]) -> dict[str, list[RuleDoc]]:
+    """Group rule docs by level and preserve catalog order within each group."""
+    groups: dict[str, list[RuleDoc]] = {}
+    for doc in docs:
+        groups.setdefault(doc.rule_type.level.value, []).append(doc)
+    return groups
+
+
+def render_rule_page(doc: RuleDoc) -> str:
+    """Render a single rule's standalone Markdown page."""
+    source_url = f"{_REPO_SOURCE_URL}/{doc.relative_source_path.as_posix()}"
+    summary = doc.parsed.summary or doc.parsed.objective or ""
+
+    lines: list[str] = [
+        "---",
+        "icon: lucide/shield-check",
+        f"title: {doc.title}",
+        f"description: {summary}",
+        "---",
+        "",
+        '<div class="sg-rule-page" markdown>',
+        "",
+        _render_header(doc, summary, source_url),
+        "",
+        _render_meta_row(doc),
+        "",
+        "## Behavior",
+        "",
+        _render_behavior_table(doc),
+        "",
+    ]
+    if doc.parsed.severity:
+        lines.extend(["## Severity", "", doc.parsed.severity, ""])
+    for extra in doc.parsed.extras:
+        lines.extend([f"## {extra.title}", "", extra.body, ""])
+    lines.extend(
+        [
+            "## Default configuration",
+            "",
+            _render_defaults(doc.defaults),
+            "",
+        ]
+    )
+    if doc.contributors:
+        lines.extend(
+            [
+                "## Contributors",
+                "",
+                _render_contributors(doc.contributors),
+                "",
+            ]
+        )
+    lines.append("</div>")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_index_card(doc: RuleDoc) -> str:
+    """Render one rule as a compact card on the landing page."""
+    summary = doc.parsed.summary or doc.parsed.objective or ""
+    return "\n".join(
+        [
+            '<div class="sg-rule-card">',
+            f'  <a class="sg-rule-card__link" href="{doc.slug}.md">',
+            f'    <div class="sg-rule-card__head">'
+            f'<span class="sg-rule-card__title">{doc.title}</span></div>',
+            f'    <p class="sg-rule-card__summary">{summary}</p>',
+            "  </a>",
+            "</div>",
+        ]
+    )
+
+
+def render_index_page(docs: list[RuleDoc]) -> str:
+    """Render the rule library overview page with per-level card grids."""
+    groups = _group_by_level(docs)
+    total = len(docs)
+    header = [
+        "---",
+        "icon: lucide/list-checks",
+        "title: Rule library",
+        "description: Catalog of the rules that slop-guard runs on every check.",
+        "---",
+        "",
+        "# Rule library",
+        "",
+        "`slop-guard` ships a pipeline of small, independently scored rules. "
+        "Each rule targets one formulaic pattern, flags the exact matching "
+        "spans, and contributes a penalty toward the final score.",
+        "",
+        f"The default pipeline runs **{total} rules** across four scopes. "
+        "Open a card to read the full rule page, including example "
+        "violations, default thresholds, and a link to the source file.",
+        "",
+    ]
+    body: list[str] = []
+    for level in _LEVEL_ORDER:
+        level_docs = groups.get(level)
+        if not level_docs:
+            continue
+        body.append(f"## {_LEVEL_LABEL[level]} rules")
+        body.append("")
+        body.append(_LEVEL_BLURB[level])
+        body.append("")
+        body.append('<div class="sg-rule-grid">')
+        for doc in level_docs:
+            body.append(_render_index_card(doc))
+        body.append("</div>")
+        body.append("")
+    return "\n".join(header + body).rstrip() + "\n"
+
+
+def _reset_output_dir(output_dir: Path) -> None:
+    """Remove the generated rule directory so stale pages are cleaned up."""
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+
+def build_rule_docs() -> list[RuleDoc]:
+    """Return parsed rule docs for every rule in the default catalog."""
+    defaults = _load_default_configs()
+    return [_load_rule_doc(path, defaults) for path in DEFAULT_RULE_PATHS]
+
+
+def nav_entries(docs: list[RuleDoc]) -> list[dict[str, Any]]:
+    """Return a TOML-friendly nav structure for the rule library."""
+    groups = _group_by_level(docs)
+    entries: list[dict[str, Any]] = [{"Overview": "rules/index.md"}]
+    for level in _LEVEL_ORDER:
+        level_docs = groups.get(level)
+        if not level_docs:
+            continue
+        children: list[dict[str, str]] = [
+            {doc.title: f"rules/{doc.slug}.md"} for doc in level_docs
+        ]
+        entries.append({f"{_LEVEL_LABEL[level]} rules": children})
+    return entries
+
+
+def main() -> None:
+    """Write the rule index and one page per rule to the docs tree."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=_DEFAULT_OUTPUT_DIR,
+        help="Directory that will contain the generated rule pages.",
+    )
+    args = parser.parse_args()
+
+    docs = build_rule_docs()
+    _reset_output_dir(args.output_dir)
+
+    index_path = args.output_dir / "index.md"
+    index_path.write_text(render_index_page(docs), encoding="utf-8")
+    for doc in docs:
+        (args.output_dir / f"{doc.slug}.md").write_text(
+            render_rule_page(doc), encoding="utf-8"
+        )
+    print(f"wrote {len(docs)} rule pages and an index to {args.output_dir}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/zensical.toml
+++ b/zensical.toml
@@ -13,14 +13,48 @@ nav = [
   { "Overview" = "index.md" },
   { "Get Started" = "get-started.md" },
   { "Agents" = "agents.md" },
+  { "Rules" = [
+    { "Overview" = "rules/index.md" },
+    { "Word rules" = [
+      { "Slop Word" = "rules/slop-word.md" },
+    ] },
+    { "Sentence rules" = [
+      { "Slop Phrase" = "rules/slop-phrase.md" },
+      { "Tone Marker" = "rules/tone-marker.md" },
+      { "Weasel Phrase" = "rules/weasel-phrase.md" },
+      { "AI Disclosure" = "rules/ai-disclosure.md" },
+      { "Placeholder" = "rules/placeholder.md" },
+      { "Contrast Pair" = "rules/contrast-pair.md" },
+      { "Intrasentence Keyword Bold" = "rules/intrasentence-keyword-bold.md" },
+      { "Setup Resolution" = "rules/setup-resolution.md" },
+      { "Pithy Fragment" = "rules/pithy-fragment.md" },
+    ] },
+    { "Paragraph rules" = [
+      { "Structural Pattern" = "rules/structural-pattern.md" },
+      { "Bullet Density" = "rules/bullet-density.md" },
+      { "Blockquote Density" = "rules/blockquote-density.md" },
+      { "Bold Term Bullet Run" = "rules/bold-term-bullet-run.md" },
+      { "Horizontal Rule Overuse" = "rules/horizontal-rule-overuse.md" },
+    ] },
+    { "Passage rules" = [
+      { "Rhythm" = "rules/rhythm.md" },
+      { "Em Dash Density" = "rules/em-dash-density.md" },
+      { "Colon Density" = "rules/colon-density.md" },
+      { "Phrase Reuse" = "rules/phrase-reuse.md" },
+      { "Copula Chain" = "rules/copula-chain.md" },
+      { "Extreme Sentence" = "rules/extreme-sentence.md" },
+      { "Closing Aphorism" = "rules/closing-aphorism.md" },
+      { "Paragraph Balance" = "rules/paragraph-balance.md" },
+      { "Paragraph CV" = "rules/paragraph-cv.md" },
+    ] },
+  ] },
 ]
+extra_css = ["stylesheets/extra.css"]
 
 [project.theme]
 logo = "images/icon_transparent_2.png"
 favicon = "images/icon_transparent_2.png"
 features = [
-  "content.action.edit",
-  "content.action.view",
   "content.code.copy",
   "navigation.footer",
   "navigation.path",
@@ -29,12 +63,16 @@ features = [
 [[project.theme.palette]]
 media = "(prefers-color-scheme: light)"
 scheme = "default"
+primary = "custom"
+accent = "custom"
 toggle.icon = "lucide/sun"
 toggle.name = "Switch to dark mode"
 
 [[project.theme.palette]]
 media = "(prefers-color-scheme: dark)"
 scheme = "slate"
+primary = "custom"
+accent = "custom"
 toggle.icon = "lucide/moon"
 toggle.name = "Switch to light mode"
 


### PR DESCRIPTION
## Description

Adds a complete Rule Library to the Zensical docs site. The library is generated at build time from the rules themselves: `tools/docs_rules.py` imports every class in `DEFAULT_RULE_PATHS`, parses the module docstring (summary, objective, severity, example violations/non-violations, plus any free-form extra sections like `Notes:`), pulls default config values from `assets/default.jsonl`, aggregates contributors by running `git log --follow` over the source file and resolving each author's GitHub login via `gh api`, and writes one dedicated Markdown page per rule under `docs/rules/` plus an overview index.

The rule-page template matches a consistent structural layout:
- Level eyebrow (color-coded per level), title, and a small "source" chip that links to the file on GitHub
- Lede paragraph derived from the docstring summary
- Three-column meta strip: Class / Rule name / Count key
- `## Behavior` — a single table combining Flag and Pass examples with colored status dots, monospace input text, and the rationale in the "Why" column
- `## Severity` prose
- Any free-form `## Notes` (or other author-defined) sections declared in the docstring
- `## Default configuration` — an auto-fit grid of labeled parameters pulled from the packaged JSONL
- `## Contributors` — avatar chips with `@handle` for everyone whose commits touched the file, derived from `git log --follow` + `gh api` (cached by email)

The overview page at `docs/rules/index.md` groups rules by scope (Word, Sentence, Paragraph, Passage) and renders a responsive card grid so each rule is one click away. Nav was restructured to expose every rule under a nested Rules → {level} rules → {rule} hierarchy in the sidebar.

Styling lives in `docs/stylesheets/extra.css` alongside a new Zensical palette override that aligns the light and dark docs schemes with the landing-page palette (paper cream, warm ink, teal primary, coral accent, gold highlight). Typography on the rule pages uses em-relative sizes so it inherits `.md-typeset`'s base and stays in sync with the nav and breadcrumbs.

## Why?

Before this change, the rules were only discoverable by reading Python source files. That worked for contributors but not for anyone evaluating whether `slop-guard` catches the patterns they care about, tuning thresholds, or figuring out which rule fired a given violation. A versioned, navigable rule catalog is the missing piece between the landing page's pitch and the CLI's output, and wiring it to the source of truth (rule classes + JSONL defaults + git history) means it cannot drift out of date.

The template also gives rule authors a predictable surface: any new rule that follows the existing docstring convention gets a fully rendered page for free, with contributors automatically backfilled from `git log`. Author-specific free-form sections (the new `Notes:` demo on `ContrastPairRule` shows the pattern) let rule authors add nuance without touching the generator.

## Usage / Demonstration

Regenerate the rule library after changing a rule docstring or adding a new rule:

```bash
make docs-rules
```

Preview the site locally — this target regenerates the rule pages before launching Zensical:

```bash
make docs-serve
```

Build for release (also auto-regenerates):

```bash
make docs-build
```

Run the prose lint over human-written docs (the generator output is excluded since it embeds intentional slop examples as part of each rule's definition):

```bash
make docs-check
```

To add a new free-form section to any rule, extend the module docstring with a new header; the generator picks it up automatically and renders it as an `##` section in docstring order:

```python
"""Detect repeated contrast constructions that stage a binary opposition.

...

Severity: Low per instance, medium when repeated frequently in one passage.

Notes: Detection is purely pattern-based — legitimate contrasts may still be
flagged when density exceeds the configured threshold. Adjust \`advice_min\` to
tune when summary advice appears.
"""
```

## Verification

- \`make check\` passes: ruff format, ruff lint, ty typecheck, and pytest with 81.77% coverage (181 tests)
- \`make docs-build\` produces a clean Zensical build with 24 rule pages plus the index
- \`make docs-check\` runs \`sg -t 60\` over README and hand-written docs; all clean at 100/100
- Spot-checked multiple rule pages in both light and dark schemes, verified the nested nav expands correctly, confirmed contributor chips render with avatars from \`https://github.com/{login}.png\`, and confirmed the breadcrumb, "On this page" TOC, and source chip all link through correctly
- Confirmed the \`Notes:\` demo on \`ContrastPairRule\` renders as a live section, proving free-form extras flow end-to-end

## Issues

No linked issues — this is a documentation initiative rather than a bug fix.