### PR TITLE
Document rule config fields with metadata descriptions

### DIFF
--- a/src/slop_guard/rules/paragraph/blockquote_density.py
+++ b/src/slop_guard/rules/paragraph/blockquote_density.py
@@ -19,7 +19,7 @@ Severity: Medium; usually indicates a style issue rather than factual error.
 """
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -38,10 +38,38 @@ from slop_guard.rules.fitting import (
 class BlockquoteDensityRuleConfig(RuleConfig):
     """Config for blockquote overuse detection."""
 
-    min_lines: int
-    free_lines: int
-    cap: int
-    penalty_step: int
+    min_lines: int = field(
+        metadata={
+            "description": (
+                "Minimum number of blockquote lines (outside code fences) that "
+                "must appear in the document before the rule fires at all."
+            )
+        }
+    )
+    free_lines: int = field(
+        metadata={
+            "description": (
+                "Number of blockquote lines excluded from the penalty budget; "
+                "only the count beyond this threshold contributes to the penalty."
+            )
+        }
+    )
+    cap: int = field(
+        metadata={
+            "description": (
+                "Maximum excess blockquote-line count used when scaling the "
+                "penalty, so a very long run cannot produce an unbounded score."
+            )
+        }
+    )
+    penalty_step: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per unit of capped excess blockquote lines "
+                "(final penalty is penalty_step * min(excess, cap))."
+            )
+        }
+    )
 
 
 class BlockquoteDensityRule(Rule[BlockquoteDensityRuleConfig]):

--- a/src/slop_guard/rules/paragraph/bold_term_bullet_run.py
+++ b/src/slop_guard/rules/paragraph/bold_term_bullet_run.py
@@ -19,7 +19,7 @@ Severity: Medium to high when long runs appear in the same section.
 """
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -36,8 +36,22 @@ from slop_guard.rules.fitting import (
 class BoldTermBulletRunRuleConfig(RuleConfig):
     """Config for bold-term bullet run thresholds."""
 
-    min_run_length: int
-    penalty: int
+    min_run_length: int = field(
+        metadata={
+            "description": (
+                "Minimum number of contiguous bullets that each start with a "
+                "bold term required to fire the run violation."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied for each qualifying run that meets or "
+                "exceeds min_run_length."
+            )
+        }
+    )
 
 
 class BoldTermBulletRunRule(Rule[BoldTermBulletRunRuleConfig]):

--- a/src/slop_guard/rules/paragraph/bullet_density.py
+++ b/src/slop_guard/rules/paragraph/bullet_density.py
@@ -18,7 +18,7 @@ Example Non-Violations:
 Severity: Medium to high depending on how much of the passage is list-form.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -33,8 +33,23 @@ from slop_guard.rules.fitting import (
 class BulletDensityRuleConfig(RuleConfig):
     """Config for bullet density thresholds."""
 
-    ratio_threshold: float
-    penalty: int
+    ratio_threshold: float = field(
+        metadata={
+            "description": (
+                "Maximum allowed fraction of non-empty lines that may be "
+                "bullets before the violation fires (value between 0.0 and "
+                "1.0; a bullet ratio strictly greater than this triggers)."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when the bullet line ratio exceeds "
+                "ratio_threshold."
+            )
+        }
+    )
 
 
 class BulletDensityRule(Rule[BulletDensityRuleConfig]):

--- a/src/slop_guard/rules/paragraph/horizontal_rule_overuse.py
+++ b/src/slop_guard/rules/paragraph/horizontal_rule_overuse.py
@@ -20,7 +20,7 @@ Severity: Low to medium; mostly a formatting signal unless heavily repeated.
 
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -37,8 +37,22 @@ _HORIZONTAL_RULE_RE = re.compile(r"^\s*(?:---+|\*\*\*+|___+)\s*$", re.MULTILINE)
 class HorizontalRuleOveruseRuleConfig(RuleConfig):
     """Config for horizontal rule overuse thresholds."""
 
-    min_count: int
-    penalty: int
+    min_count: int = field(
+        metadata={
+            "description": (
+                "Minimum number of markdown horizontal-rule separators "
+                "(---, ***, ___) that must appear in the document before "
+                "the overuse violation fires."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when the horizontal-rule count reaches min_count."
+            )
+        }
+    )
 
 
 class HorizontalRuleOveruseRule(Rule[HorizontalRuleOveruseRuleConfig]):

--- a/src/slop_guard/rules/paragraph/structural_pattern.py
+++ b/src/slop_guard/rules/paragraph/structural_pattern.py
@@ -20,7 +20,7 @@ Severity: Medium to high when multiple structural signals co-occur.
 
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument, context_around
 from slop_guard.models import RuleResult, Violation
@@ -54,14 +54,71 @@ def _triadic_advice(snippet: str) -> str:
 class StructuralPatternRuleConfig(RuleConfig):
     """Config for listicle-like structural pattern thresholds."""
 
-    bold_header_min: int
-    bold_header_penalty: int
-    bullet_run_min: int
-    bullet_run_penalty: int
-    triadic_record_cap: int
-    triadic_penalty: int
-    triadic_advice_min: int
-    context_window_chars: int
+    bold_header_min: int = field(
+        metadata={
+            "description": (
+                "Minimum number of **Bold.** header-style matches required in "
+                "the document before the bold-header listicle violation fires."
+            )
+        }
+    )
+    bold_header_penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when the bold-header count reaches "
+                "bold_header_min."
+            )
+        }
+    )
+    bullet_run_min: int = field(
+        metadata={
+            "description": (
+                "Minimum length of a contiguous run of bullet lines that "
+                "triggers the excessive-bullets violation."
+            )
+        }
+    )
+    bullet_run_penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied for each contiguous bullet run that meets or "
+                "exceeds bullet_run_min."
+            )
+        }
+    )
+    triadic_record_cap: int = field(
+        metadata={
+            "description": (
+                "Maximum number of 'X, Y, and Z' triadic matches recorded as "
+                "individual violations in a single pass; further matches are "
+                "still counted but not reported individually."
+            )
+        }
+    )
+    triadic_penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied to each recorded triadic match up to "
+                "triadic_record_cap."
+            )
+        }
+    )
+    triadic_advice_min: int = field(
+        metadata={
+            "description": (
+                "Threshold on the total triadic-match count at or above which "
+                "a summary advice line about triadic cadence is emitted."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each triadic violation."
+            )
+        }
+    )
 
 
 class StructuralPatternRule(Rule[StructuralPatternRuleConfig]):

--- a/src/slop_guard/rules/passage/closing_aphorism.py
+++ b/src/slop_guard/rules/passage/closing_aphorism.py
@@ -22,7 +22,7 @@ Severity: Low; fires at most once per passage on the closing sentence only.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -56,8 +56,22 @@ _MIN_PATTERN_MATCHES = 2
 class ClosingAphorismRuleConfig(RuleConfig):
     """Config for closing aphorism detection."""
 
-    min_sentences: int
-    penalty: int
+    min_sentences: int = field(
+        metadata={
+            "description": (
+                "Minimum total sentence count required before the closing "
+                "sentence is inspected; shorter passages are skipped."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when the closing sentence matches "
+                "enough generalizing/moralizing patterns."
+            )
+        }
+    )
 
 
 class ClosingAphorismRule(Rule[ClosingAphorismRuleConfig]):

--- a/src/slop_guard/rules/passage/colon_density.py
+++ b/src/slop_guard/rules/passage/colon_density.py
@@ -19,7 +19,7 @@ Severity: Low to medium; punctuation style signal that compounds with others.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -38,9 +38,32 @@ _JSON_COLON_RE = re.compile(r': ["{\[\d]|: true|: false|: null')
 class ColonDensityRuleConfig(RuleConfig):
     """Config for elaboration-colon density checks."""
 
-    words_basis: float
-    density_threshold: float
-    penalty: int
+    words_basis: float = field(
+        metadata={
+            "description": (
+                "Word count used as the denominator basis for computing "
+                "elaboration-colon density (typically 150); density is "
+                "reported as colons per this many prose words."
+            )
+        }
+    )
+    density_threshold: float = field(
+        metadata={
+            "description": (
+                "Maximum allowed elaboration colons per words_basis prose "
+                "words; a density strictly greater than this threshold "
+                "triggers the violation."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when elaboration-colon density "
+                "exceeds density_threshold."
+            )
+        }
+    )
 
 
 class ColonDensityRule(Rule[ColonDensityRuleConfig]):

--- a/src/slop_guard/rules/passage/copula_chain.py
+++ b/src/slop_guard/rules/passage/copula_chain.py
@@ -19,7 +19,7 @@ Severity: Medium; a single passage-level flag with concentrated penalty.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -33,9 +33,30 @@ _COPULA_FIRST_WORDS_RE = re.compile(r"\b(is|are|was|were)\b", re.IGNORECASE)
 class CopulaChainRuleConfig(RuleConfig):
     """Config for copula-chain density detection."""
 
-    min_sentences: int
-    threshold: float
-    penalty: int
+    min_sentences: int = field(
+        metadata={
+            "description": (
+                "Minimum total sentence count required before copula density "
+                "is evaluated; shorter passages are skipped."
+            )
+        }
+    )
+    threshold: float = field(
+        metadata={
+            "description": (
+                "Minimum fraction of sentences that use a copula (is/are/"
+                "was/were) within the first six words needed to trigger "
+                "the violation (value between 0.0 and 1.0)."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when copula density meets or exceeds threshold."
+            )
+        }
+    )
 
 
 class CopulaChainRule(Rule[CopulaChainRuleConfig]):

--- a/src/slop_guard/rules/passage/em_dash_density.py
+++ b/src/slop_guard/rules/passage/em_dash_density.py
@@ -19,7 +19,7 @@ Severity: Low to medium; stylistic alone, but meaningful when persistent.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -36,9 +36,30 @@ _EM_DASH_RE = re.compile(r"\u2014| -- ")
 class EmDashDensityRuleConfig(RuleConfig):
     """Config for em dash density thresholding."""
 
-    words_basis: float
-    density_threshold: float
-    penalty: int
+    words_basis: float = field(
+        metadata={
+            "description": (
+                "Word count used as the denominator basis for computing "
+                "em-dash density (typically 150); density is reported as "
+                "em dashes per this many words."
+            )
+        }
+    )
+    density_threshold: float = field(
+        metadata={
+            "description": (
+                "Maximum allowed em dashes per words_basis words; a density "
+                "strictly greater than this threshold triggers the violation."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when em-dash density exceeds density_threshold."
+            )
+        }
+    )
 
 
 class EmDashDensityRule(Rule[EmDashDensityRuleConfig]):

--- a/src/slop_guard/rules/passage/extreme_sentence.py
+++ b/src/slop_guard/rules/passage/extreme_sentence.py
@@ -16,7 +16,7 @@ Example Non-Violations:
 Severity: Medium; each hit adds structural evidence of generated text.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -28,8 +28,22 @@ from slop_guard.rules.fitting import fit_penalty_contrastive
 class ExtremeSentenceRuleConfig(RuleConfig):
     """Config for extreme sentence length detection."""
 
-    min_words: int
-    penalty: int
+    min_words: int = field(
+        metadata={
+            "description": (
+                "Minimum sentence length (in words) that qualifies as a "
+                "run-on; any sentence with at least this many words emits "
+                "a violation."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per sentence that meets or exceeds min_words."
+            )
+        }
+    )
 
 
 class ExtremeSentenceRule(Rule[ExtremeSentenceRuleConfig]):

--- a/src/slop_guard/rules/passage/paragraph_rhythm.py
+++ b/src/slop_guard/rules/passage/paragraph_rhythm.py
@@ -23,7 +23,7 @@ Severity: Low to medium; stronger when combined with other rhythm signals.
 
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -47,9 +47,32 @@ def _paragraph_word_counts(text: str) -> list[int]:
 class ParagraphBalanceRuleConfig(RuleConfig):
     """Config for paragraph balance ratio detection."""
 
-    min_body_paragraphs: int
-    balance_threshold: float
-    penalty: int
+    min_body_paragraphs: int = field(
+        metadata={
+            "description": (
+                "Minimum number of body paragraphs (paragraphs after the "
+                "first) required before the balance ratio is evaluated."
+            )
+        }
+    )
+    balance_threshold: float = field(
+        metadata={
+            "description": (
+                "Maximum allowed min/max word-count ratio across body "
+                "paragraphs; a ratio strictly greater than this value "
+                "indicates suspiciously uniform paragraph sizes and "
+                "triggers the violation (value between 0.0 and 1.0)."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when the body paragraph balance ratio "
+                "exceeds balance_threshold."
+            )
+        }
+    )
 
 
 class ParagraphBalanceRule(Rule[ParagraphBalanceRuleConfig]):
@@ -151,9 +174,32 @@ class ParagraphBalanceRule(Rule[ParagraphBalanceRuleConfig]):
 class ParagraphCVRuleConfig(RuleConfig):
     """Config for paragraph length coefficient-of-variation detection."""
 
-    min_paragraphs: int
-    cv_threshold: float
-    penalty: int
+    min_paragraphs: int = field(
+        metadata={
+            "description": (
+                "Minimum number of paragraphs required before the "
+                "paragraph-length CV is evaluated."
+            )
+        }
+    )
+    cv_threshold: float = field(
+        metadata={
+            "description": (
+                "Lower bound on the paragraph-length coefficient of "
+                "variation (std/mean). A CV strictly below this value "
+                "indicates overly uniform paragraph rhythm and triggers "
+                "the violation."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when the paragraph-length CV falls "
+                "below cv_threshold."
+            )
+        }
+    )
 
 
 class ParagraphCVRule(Rule[ParagraphCVRuleConfig]):

--- a/src/slop_guard/rules/passage/phrase_reuse.py
+++ b/src/slop_guard/rules/passage/phrase_reuse.py
@@ -19,7 +19,7 @@ Severity: Medium to high; repeated long phrases are strong formulaicity signals.
 """
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.config import Hyperparameters
 from slop_guard.document import AnalysisDocument
@@ -43,11 +43,45 @@ from slop_guard.rules.ngrams import (
 class PhraseReuseRuleConfig(RuleConfig):
     """Config for phrase-reuse detection and recording."""
 
-    penalty: int
-    record_cap: int
-    repeated_ngram_min_n: int
-    repeated_ngram_max_n: int
-    repeated_ngram_min_count: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per recorded repeated n-gram phrase match."
+            )
+        }
+    )
+    record_cap: int = field(
+        metadata={
+            "description": (
+                "Maximum number of repeated-phrase findings recorded as "
+                "individual violations in a single pass."
+            )
+        }
+    )
+    repeated_ngram_min_n: int = field(
+        metadata={
+            "description": (
+                "Minimum n-gram length (in words) considered when scanning "
+                "for repeated phrases; shorter phrases are ignored."
+            )
+        }
+    )
+    repeated_ngram_max_n: int = field(
+        metadata={
+            "description": (
+                "Maximum n-gram length (in words) considered when scanning "
+                "for repeated phrases."
+            )
+        }
+    )
+    repeated_ngram_min_count: int = field(
+        metadata={
+            "description": (
+                "Minimum number of occurrences an n-gram must reach within "
+                "the document to qualify as a repeated-phrase violation."
+            )
+        }
+    )
 
 
 class PhraseReuseRule(Rule[PhraseReuseRuleConfig]):

--- a/src/slop_guard/rules/passage/rhythm.py
+++ b/src/slop_guard/rules/passage/rhythm.py
@@ -19,7 +19,7 @@ Severity: Medium; a useful style signal that is stronger with other findings.
 """
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -37,9 +37,31 @@ from slop_guard.rules.fitting import (
 class RhythmRuleConfig(RuleConfig):
     """Config for rhythm variance thresholding."""
 
-    min_sentences: int
-    cv_threshold: float
-    penalty: int
+    min_sentences: int = field(
+        metadata={
+            "description": (
+                "Minimum number of sentences required before the rhythm rule "
+                "attempts any variance analysis; shorter passages are "
+                "skipped entirely."
+            )
+        }
+    )
+    cv_threshold: float = field(
+        metadata={
+            "description": (
+                "Lower bound on the sentence-length coefficient of variation "
+                "(std/mean). A CV strictly below this value indicates overly "
+                "uniform cadence and triggers a violation."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when the passage falls below cv_threshold."
+            )
+        }
+    )
 
 
 class RhythmRule(Rule[RhythmRuleConfig]):

--- a/src/slop_guard/rules/sentence/ai_disclosure.py
+++ b/src/slop_guard/rules/sentence/ai_disclosure.py
@@ -19,7 +19,7 @@ Severity: High; disclosure phrases are strong and explicit AI-origin signals.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument, context_around
 from slop_guard.models import RuleResult, Violation
@@ -53,8 +53,22 @@ _AI_DISCLOSURE_COMPLEX_PATTERNS: tuple[re.Pattern[str], ...] = (
 class AIDisclosureRuleConfig(RuleConfig):
     """Config for AI self-disclosure pattern matching."""
 
-    penalty: int
-    context_window_chars: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once per matched AI self-disclosure phrase "
+                "(for example 'as an AI' or 'as of my knowledge cutoff')."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each AI-disclosure violation."
+            )
+        }
+    )
 
 
 class AIDisclosureRule(Rule[AIDisclosureRuleConfig]):

--- a/src/slop_guard/rules/sentence/contrast_pair.py
+++ b/src/slop_guard/rules/sentence/contrast_pair.py
@@ -21,7 +21,7 @@ Severity: Low per instance, medium when repeated frequently in one passage.
 
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, TypeAlias
 
 from slop_guard.document import AnalysisDocument, context_around
@@ -119,10 +119,38 @@ def _contrast_summary_advice(
 class ContrastPairRuleConfig(RuleConfig):
     """Config for contrast pair detection and recording limits."""
 
-    penalty: int
-    record_cap: int
-    advice_min: int
-    context_window_chars: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per recorded contrast-pair match (for "
+                "example 'X, not Y' or 'not only X but Y')."
+            )
+        }
+    )
+    record_cap: int = field(
+        metadata={
+            "description": (
+                "Maximum number of contrast-pair matches recorded as "
+                "individual violations in a single pass."
+            )
+        }
+    )
+    advice_min: int = field(
+        metadata={
+            "description": (
+                "Threshold on the total contrast-pair match count at or "
+                "above which a summary advice line is emitted."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each contrast-pair violation."
+            )
+        }
+    )
 
 
 class ContrastPairRule(Rule[ContrastPairRuleConfig]):

--- a/src/slop_guard/rules/sentence/intrasentence_keyword_bold.py
+++ b/src/slop_guard/rules/sentence/intrasentence_keyword_bold.py
@@ -25,7 +25,7 @@ Severity: Low per instance, medium when repeated frequently in one passage.
 import math
 import re
 from bisect import bisect_right
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypeAlias
 
 from slop_guard.document import AnalysisDocument, context_around
@@ -182,11 +182,45 @@ def _collect_keyword_bold_matches(
 class IntrasentenceKeywordBoldRuleConfig(RuleConfig):
     """Config for the intra-sentence keyword bold detector."""
 
-    penalty: int
-    record_cap: int
-    advice_min: int
-    max_words: int
-    context_window_chars: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per recorded mid-sentence keyword-bold span match."
+            )
+        }
+    )
+    record_cap: int = field(
+        metadata={
+            "description": (
+                "Maximum number of keyword-bold matches recorded as "
+                "individual violations in a single pass."
+            )
+        }
+    )
+    advice_min: int = field(
+        metadata={
+            "description": (
+                "Threshold on the total keyword-bold match count at or "
+                "above which a summary advice line is emitted."
+            )
+        }
+    )
+    max_words: int = field(
+        metadata={
+            "description": (
+                "Maximum span length (in words) eligible to match as an "
+                "intra-sentence keyword bold; longer bold spans are skipped."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each keyword-bold violation."
+            )
+        }
+    )
 
 
 class IntrasentenceKeywordBoldRule(Rule[IntrasentenceKeywordBoldRuleConfig]):

--- a/src/slop_guard/rules/sentence/pithy_fragment.py
+++ b/src/slop_guard/rules/sentence/pithy_fragment.py
@@ -20,7 +20,7 @@ Severity: Low to medium; mostly stylistic alone, stronger when clustered.
 
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument
 from slop_guard.models import RuleResult, Violation
@@ -39,9 +39,30 @@ _PITHY_PIVOT_RE = re.compile(r",\s+(?:but|yet|and|not|or)\b", re.IGNORECASE)
 class PithyFragmentRuleConfig(RuleConfig):
     """Config for pithy fragment thresholds."""
 
-    penalty: int
-    max_sentence_words: int
-    record_cap: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per recorded pithy-fragment match "
+                "(for example 'Simple, but powerful.')."
+            )
+        }
+    )
+    max_sentence_words: int = field(
+        metadata={
+            "description": (
+                "Maximum sentence length (in words) eligible to match as a "
+                "pithy fragment; longer sentences are skipped."
+            )
+        }
+    )
+    record_cap: int = field(
+        metadata={
+            "description": (
+                "Maximum number of pithy-fragment matches recorded as "
+                "individual violations in a single pass."
+            )
+        }
+    )
 
 
 class PithyFragmentRule(Rule[PithyFragmentRuleConfig]):

--- a/src/slop_guard/rules/sentence/placeholder.py
+++ b/src/slop_guard/rules/sentence/placeholder.py
@@ -20,7 +20,7 @@ content and should generally be fixed before release.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument, context_around
 from slop_guard.models import RuleResult, Violation
@@ -37,8 +37,22 @@ _PLACEHOLDER_RE = re.compile(
 class PlaceholderRuleConfig(RuleConfig):
     """Config for placeholder text detection."""
 
-    penalty: int
-    context_window_chars: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once per matched bracketed placeholder "
+                "(for example '[insert source]' or '[your email here]')."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each placeholder violation."
+            )
+        }
+    )
 
 
 class PlaceholderRule(Rule[PlaceholderRuleConfig]):

--- a/src/slop_guard/rules/sentence/setup_resolution.py
+++ b/src/slop_guard/rules/sentence/setup_resolution.py
@@ -19,7 +19,7 @@ Severity: Medium; repeated occurrences strongly suggest formulaic generation.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument, context_around
 from slop_guard.models import RuleResult, Violation
@@ -56,9 +56,31 @@ _SETUP_RESOLUTION_B_RE = re.compile(
 class SetupResolutionRuleConfig(RuleConfig):
     """Config for setup-resolution pattern detection."""
 
-    penalty: int
-    record_cap: int
-    context_window_chars: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per recorded setup-resolution match "
+                "(for example \"This isn't X. It's Y.\")."
+            )
+        }
+    )
+    record_cap: int = field(
+        metadata={
+            "description": (
+                "Maximum number of setup-resolution matches recorded as "
+                "individual violations in a single pass; further matches "
+                "still contribute to the count but are not reported."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each setup-resolution violation."
+            )
+        }
+    )
 
 
 class SetupResolutionRule(Rule[SetupResolutionRuleConfig]):

--- a/src/slop_guard/rules/sentence/slop_phrase.py
+++ b/src/slop_guard/rules/sentence/slop_phrase.py
@@ -19,7 +19,7 @@ Severity: Medium; each hit is a strong indicator of templated writing style.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument, context_around
 from slop_guard.models import RuleResult, Violation
@@ -200,8 +200,22 @@ def _slop_phrase_advice(phrase: str) -> str:
 class SlopPhraseRuleConfig(RuleConfig):
     """Config for phrase-level slop pattern matching."""
 
-    penalty: int
-    context_window_chars: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per matched slop phrase or 'not just X, "
+                "but Y' transition template."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each slop-phrase violation."
+            )
+        }
+    )
 
 
 class SlopPhraseRule(Rule[SlopPhraseRuleConfig]):

--- a/src/slop_guard/rules/sentence/tone_marker.py
+++ b/src/slop_guard/rules/sentence/tone_marker.py
@@ -20,7 +20,7 @@ Severity: Medium to high; often a strong signal of assistant-authored tone.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument, context_around
 from slop_guard.models import RuleResult, Violation
@@ -75,9 +75,31 @@ def _false_narrativity_advice(phrase: str) -> str:
 class ToneMarkerRuleConfig(RuleConfig):
     """Config for tone marker pattern matching."""
 
-    tone_penalty: int
-    sentence_opener_penalty: int
-    context_window_chars: int
+    tone_penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per matched meta-communication or "
+                "false-narrativity tone-marker phrase (for example 'would "
+                "you like' or 'this is where things get interesting')."
+            )
+        }
+    )
+    sentence_opener_penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per matched stylized sentence opener "
+                "(for example 'Certainly,' or 'Absolutely!')."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each tone-marker violation."
+            )
+        }
+    )
 
 
 class ToneMarkerRule(Rule[ToneMarkerRuleConfig]):

--- a/src/slop_guard/rules/sentence/weasel_phrase.py
+++ b/src/slop_guard/rules/sentence/weasel_phrase.py
@@ -19,7 +19,7 @@ Severity: Medium; each hit indicates weak attribution and rhetorical padding.
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from slop_guard.document import AnalysisDocument, context_around
 from slop_guard.models import RuleResult, Violation
@@ -47,8 +47,22 @@ _WEASEL_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
 class WeaselPhraseRuleConfig(RuleConfig):
     """Config for weasel phrase detection."""
 
-    penalty: int
-    context_window_chars: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once per matched weasel phrase (for example "
+                "'many believe' or 'studies show')."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each weasel-phrase violation."
+            )
+        }
+    )
 
 
 class WeaselPhraseRule(Rule[WeaselPhraseRuleConfig]):

--- a/src/slop_guard/rules/word/slop_word.py
+++ b/src/slop_guard/rules/word/slop_word.py
@@ -21,7 +21,7 @@ language and accumulate penalty quickly.
 
 import re
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypeAlias
 
 from slop_guard.document import AnalysisDocument, context_around
@@ -232,8 +232,21 @@ def _is_probable_proper_noun_match(text: str, match: re.Match[str]) -> bool:
 class SlopWordRuleConfig(RuleConfig):
     """Config for slop word matching behavior."""
 
-    penalty: int
-    context_window_chars: int
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once per matched slop-word occurrence in the document."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each slop-word violation."
+            )
+        }
+    )
 
 
 class SlopWordRule(Rule[SlopWordRuleConfig]):


### PR DESCRIPTION
## Description

Every rule's `RuleConfig` dataclass now documents each field via `dataclasses.field(metadata={"description": "..."})`. The descriptions explain what each hyperparameter actually controls — trigger thresholds, penalty magnitudes, recording caps, context-window widths, density bases, and skip conditions — so readers can understand a rule's knobs without reverse-engineering the `forward` and `_fit` bodies.

This touches all 24 rule configs across the four rule levels (word, sentence, paragraph, passage). No behavior changes: `dataclasses.field` with only `metadata=` leaves default semantics intact, `asdict` still round-trips, and the `RuleConfig.from_dict` / `to_dict` plumbing in `rules/base.py` and `rules/pipeline.py` is unaffected.

## Why?

Until now, each rule config field was declared as a bare type-annotated attribute with no in-code description. Anyone tuning a rule (or reading a fitted config dump) had to read the rule's implementation to learn what `free_lines`, `cv_threshold`, `words_basis`, `record_cap`, etc. actually did. Structured per-field descriptions make the configs self-documenting and set up future introspection — e.g. generating a human-readable config reference, surfacing descriptions via `sg-fit`, or validating docs against the code.

The codebase uses `@dataclass` (not Pydantic), so the native `field(metadata=...)` mechanism was the least-invasive way to attach descriptions without adding a dependency or rewriting the config base class.

## Usage / Demonstration

Descriptions are attached via `metadata` and can be read back at runtime:

```python
from dataclasses import fields
from slop_guard.rules.paragraph.blockquote_density import BlockquoteDensityRuleConfig

for f in fields(BlockquoteDensityRuleConfig):
    print(f.name, "->", f.metadata["description"])
```

Example output:

```
min_lines   -> Minimum number of blockquote lines (outside code fences) that must appear in the document before the rule fires at all.
free_lines  -> Number of blockquote lines excluded from the penalty budget; only the count beyond this threshold contributes to the penalty.
cap         -> Maximum excess blockquote-line count used when scaling the penalty, so a very long run cannot produce an unbounded score.
penalty_step-> Penalty applied per unit of capped excess blockquote lines (final penalty is penalty_step * min(excess, cap)).
```

Every rule config in `src/slop_guard/rules/{word,sentence,paragraph,passage}/` now exposes descriptions the same way.

## Verification

- `make check` passes locally: ruff format, ruff lint, ty type-check, and pytest (182 tests, 81.77% coverage, coverage gate met).
- Grepped for any remaining bare `name: type` field lines in rule configs — none found; every field is now `name: type = field(metadata={...})`.
- Confirmed `asdict`/`from_dict` round-trip is unchanged (no default values introduced; constructors still require all fields positionally or by name, matching prior behavior exercised by `test_rule_framework.py` and `test_rule_fit_learning.py`).

## Issues

None.