### PR TITLE
Fix rule card links routing to the raw markdown mirror

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -16,7 +16,7 @@ Single-token checks. These are the cheapest rules and fire on individual AI-asso
 
 <div class="sg-rule-grid">
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="slop-word.md">
+  <a class="sg-rule-card__link" href="./slop-word/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Slop Word</span></div>
     <p class="sg-rule-card__summary">Detect overused AI-associated slop words.</p>
   </a>
@@ -29,55 +29,55 @@ One sentence at a time. Catches canned phrases, disclosures, tone markers, and t
 
 <div class="sg-rule-grid">
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="slop-phrase.md">
+  <a class="sg-rule-card__link" href="./slop-phrase/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Slop Phrase</span></div>
     <p class="sg-rule-card__summary">Detect stock slop phrases and transition templates.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="tone-marker.md">
+  <a class="sg-rule-card__link" href="./tone-marker/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Tone Marker</span></div>
     <p class="sg-rule-card__summary">Detect AI-style tone markers and opener tells.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="weasel-phrase.md">
+  <a class="sg-rule-card__link" href="./weasel-phrase/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Weasel Phrase</span></div>
     <p class="sg-rule-card__summary">Detect unattributed weasel phrases.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="ai-disclosure.md">
+  <a class="sg-rule-card__link" href="./ai-disclosure/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">AI Disclosure</span></div>
     <p class="sg-rule-card__summary">Detect direct AI self-disclosure statements.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="placeholder.md">
+  <a class="sg-rule-card__link" href="./placeholder/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Placeholder</span></div>
     <p class="sg-rule-card__summary">Detect unfinished placeholder markers.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="contrast-pair.md">
+  <a class="sg-rule-card__link" href="./contrast-pair/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Contrast Pair</span></div>
     <p class="sg-rule-card__summary">Detect repeated contrast constructions that stage a binary opposition.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="intrasentence-keyword-bold.md">
+  <a class="sg-rule-card__link" href="./intrasentence-keyword-bold/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Intrasentence Keyword Bold</span></div>
     <p class="sg-rule-card__summary">Detect short, mid-sentence keyword bold spans (LLM emphasis tic).</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="setup-resolution.md">
+  <a class="sg-rule-card__link" href="./setup-resolution/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Setup Resolution</span></div>
     <p class="sg-rule-card__summary">Detect setup-resolution rhetorical flips.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="pithy-fragment.md">
+  <a class="sg-rule-card__link" href="./pithy-fragment/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Pithy Fragment</span></div>
     <p class="sg-rule-card__summary">Detect short evaluative pivot fragments.</p>
   </a>
@@ -90,31 +90,31 @@ Adjacent-line structure. Catches bullet runs, blockquotes, horizontal rules, and
 
 <div class="sg-rule-grid">
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="structural-pattern.md">
+  <a class="sg-rule-card__link" href="./structural-pattern/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Structural Pattern</span></div>
     <p class="sg-rule-card__summary">Detect listicle-like structural patterns in paragraphs.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="bullet-density.md">
+  <a class="sg-rule-card__link" href="./bullet-density/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Bullet Density</span></div>
     <p class="sg-rule-card__summary">Detect bullet-heavy document formatting.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="blockquote-density.md">
+  <a class="sg-rule-card__link" href="./blockquote-density/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Blockquote Density</span></div>
     <p class="sg-rule-card__summary">Detect excessive thesis-style blockquote usage.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="bold-term-bullet-run.md">
+  <a class="sg-rule-card__link" href="./bold-term-bullet-run/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Bold Term Bullet Run</span></div>
     <p class="sg-rule-card__summary">Detect runs of bullets that start with bold terms.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="horizontal-rule-overuse.md">
+  <a class="sg-rule-card__link" href="./horizontal-rule-overuse/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Horizontal Rule Overuse</span></div>
     <p class="sg-rule-card__summary">Detect overuse of horizontal rule separators.</p>
   </a>
@@ -127,55 +127,55 @@ Whole-document signals. Catches rhythm, density, and repetition across the full 
 
 <div class="sg-rule-grid">
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="rhythm.md">
+  <a class="sg-rule-card__link" href="./rhythm/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Rhythm</span></div>
     <p class="sg-rule-card__summary">Detect monotonous sentence-length rhythm.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="em-dash-density.md">
+  <a class="sg-rule-card__link" href="./em-dash-density/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Em Dash Density</span></div>
     <p class="sg-rule-card__summary">Detect overuse of em dashes across a passage.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="colon-density.md">
+  <a class="sg-rule-card__link" href="./colon-density/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Colon Density</span></div>
     <p class="sg-rule-card__summary">Detect elaboration-colon overuse in prose passages.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="phrase-reuse.md">
+  <a class="sg-rule-card__link" href="./phrase-reuse/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Phrase Reuse</span></div>
     <p class="sg-rule-card__summary">Detect repeated long n-gram phrase reuse.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="copula-chain.md">
+  <a class="sg-rule-card__link" href="./copula-chain/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Copula Chain</span></div>
     <p class="sg-rule-card__summary">Detect high copula-sentence density - an encyclopedic AI chain pattern.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="extreme-sentence.md">
+  <a class="sg-rule-card__link" href="./extreme-sentence/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Extreme Sentence</span></div>
     <p class="sg-rule-card__summary">Detect extremely long run-on sentences.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="closing-aphorism.md">
+  <a class="sg-rule-card__link" href="./closing-aphorism/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Closing Aphorism</span></div>
     <p class="sg-rule-card__summary">Detect moralizing or generalizing closing sentences.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="paragraph-balance.md">
+  <a class="sg-rule-card__link" href="./paragraph-balance/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Paragraph Balance</span></div>
     <p class="sg-rule-card__summary">Detect suspiciously uniform paragraph lengths.</p>
   </a>
 </div>
 <div class="sg-rule-card">
-  <a class="sg-rule-card__link" href="paragraph-cv.md">
+  <a class="sg-rule-card__link" href="./paragraph-cv/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Paragraph CV</span></div>
     <p class="sg-rule-card__summary">Detect suspiciously uniform paragraph lengths.</p>
   </a>

--- a/tools/docs_rules.py
+++ b/tools/docs_rules.py
@@ -533,7 +533,7 @@ def _render_index_card(doc: RuleDoc) -> str:
     return "\n".join(
         [
             '<div class="sg-rule-card">',
-            f'  <a class="sg-rule-card__link" href="{doc.slug}.md">',
+            f'  <a class="sg-rule-card__link" href="./{doc.slug}/">',
             f'    <div class="sg-rule-card__head">'
             f'<span class="sg-rule-card__title">{doc.title}</span></div>',
             f'    <p class="sg-rule-card__summary">{summary}</p>',


### PR DESCRIPTION
## Description

Rule cards on the rule library overview (`docs/rules/index.md`) were generated with raw `<a href="slug.md">` anchors. Zensical only rewrites `.md` links when they are written as Markdown link syntax, so these raw HTML anchors are left untouched. After PR #112 added the crawlable Markdown mirror feature, every one of those `.md` URLs started resolving to the raw mirror on the built site — so clicking a card on the live docs dumps raw markdown+HTML instead of the rendered rule page.

This PR changes the generator in `tools/docs_rules.py` to emit the rendered directory URL (`./slug/`) and regenerates `docs/rules/index.md`. The site is configured with `use_directory_urls=True`, so `rules/slop-word/index.html` is the rendered page and `./slop-word/` is the correct relative URL from the overview page.

## Why?

The regression was visible in production docs: every card on the rule library landing page routed to a raw Markdown file. Keeping the Markdown mirror (useful for LLM crawlers) and the rendered HTML on the same path space is fine, but internal navigation must target the rendered URLs.

## Usage / Demonstration

Before:

```html
<a class="sg-rule-card__link" href="slop-word.md">
```

After:

```html
<a class="sg-rule-card__link" href="./slop-word/">
```

Built-site verification:

```
$ grep -c 'href="./slop-word/"' site/rules/index.html
4   # 3 nav entries + 1 rule card
```

## Verification

- `make docs-rules` regenerates `docs/rules/index.md` with the new hrefs.
- `make docs-build` produces `site/rules/index.html` where the card hrefs point at `./slug/` and resolve to the rendered page.
- `make check` passes (182 tests, 81.77% coverage).

## Issues

None filed — reported verbally.