### PR TITLE
Add a faux deepness prose rule

### DIFF
--- a/docs/rules/faux-deepness.md
+++ b/docs/rules/faux-deepness.md
@@ -1,0 +1,55 @@
+---
+icon: lucide/shield-check
+title: Faux Deepness
+description: Detect faux-deep negations of ordinary metaphorical predicates.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Faux Deepness</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/faux_deepness.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect faux-deep negations of ordinary metaphorical predicates.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>FauxDeepnessRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>faux_deepness</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>faux_deepness</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Silence does not "settle"."</code></td><td class="sg-behavior__why">Negates an ordinary metaphor for an abstract subject.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Words do not hang in the air. History does not press."</code></td><td class="sg-behavior__why">Stacks multiple abstract negations as a depth effect.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The paint does not settle evenly in cold rooms."</code></td><td class="sg-behavior__why">Concrete subject and concrete predicate use.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The team waited in silence while the room settled."</code></td><td class="sg-behavior__why">Uses the metaphor directly instead of denying it for effect.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low per sentence, medium when repeated in one passage.
+
+## Notes
+
+This is a precision-biased pattern rule, not semantic analysis. It requires an abstract subject and either a short quoted predicate or a known metaphorical predicate from the offline lexicon.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">advice_min</span><span class="sg-defaults__value">2</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">record_cap</span><span class="sg-defaults__value">5</span></div>
+</div>
+
+</div>

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -8,7 +8,7 @@ description: Catalog of the rules that slop-guard runs on every check.
 
 `slop-guard` ships a pipeline of small, independently scored rules. Each rule targets one formulaic pattern, flags the exact matching spans, and contributes a penalty toward the final score.
 
-The default pipeline runs **24 rules** across four scopes. Open a card to read the full rule page, including example violations, default thresholds, and a link to the source file.
+The default pipeline runs **25 rules** across four scopes. Open a card to read the full rule page, including example violations, default thresholds, and a link to the source file.
 
 ## Word rules
 
@@ -62,6 +62,12 @@ One sentence at a time. Catches canned phrases, disclosures, tone markers, and t
   <a class="sg-rule-card__link" href="./contrast-pair/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Contrast Pair</span></div>
     <p class="sg-rule-card__summary">Detect repeated contrast constructions that stage a binary opposition.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./faux-deepness/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Faux Deepness</span></div>
+    <p class="sg-rule-card__summary">Detect faux-deep negations of ordinary metaphorical predicates.</p>
   </a>
 </div>
 <div class="sg-rule-card">

--- a/src/slop_guard/config.py
+++ b/src/slop_guard/config.py
@@ -11,7 +11,12 @@ class Hyperparameters:
     decay_lambda: float = 0.04
     claude_categories: frozenset[str] = field(
         default_factory=lambda: frozenset(
-            {"contrast_pairs", "pithy_fragment", "setup_resolution"}
+            {
+                "contrast_pairs",
+                "faux_deepness",
+                "pithy_fragment",
+                "setup_resolution",
+            }
         )
     )
 
@@ -45,6 +50,9 @@ class Hyperparameters:
     contrast_record_cap: int = 5
     contrast_penalty: int = -1
     contrast_advice_min: int = 2
+    faux_deepness_record_cap: int = 5
+    faux_deepness_penalty: int = -2
+    faux_deepness_advice_min: int = 2
     intrasentence_keyword_bold_penalty: int = -2
     intrasentence_keyword_bold_record_cap: int = 5
     intrasentence_keyword_bold_advice_min: int = 3

--- a/src/slop_guard/rules/assets/default.jsonl
+++ b/src/slop_guard/rules/assets/default.jsonl
@@ -8,6 +8,7 @@
 {"config": {"cv_threshold": 0.3, "min_sentences": 5, "penalty": -5}, "rule_type": "slop_guard.rules.passage.rhythm.RhythmRule"}
 {"config": {"density_threshold": 1.0, "penalty": -3, "words_basis": 150.0}, "rule_type": "slop_guard.rules.passage.em_dash_density.EmDashDensityRule"}
 {"config": {"advice_min": 2, "context_window_chars": 60, "penalty": -1, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence.contrast_pair.ContrastPairRule"}
+{"config": {"advice_min": 2, "context_window_chars": 60, "penalty": -2, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence.faux_deepness.FauxDeepnessRule"}
 {"config": {"advice_min": 3, "context_window_chars": 60, "max_words": 5, "penalty": -2, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence.intrasentence_keyword_bold.IntrasentenceKeywordBoldRule"}
 {"config": {"context_window_chars": 60, "penalty": -3, "record_cap": 5}, "rule_type": "slop_guard.rules.sentence.setup_resolution.SetupResolutionRule"}
 {"config": {"density_threshold": 1.5, "penalty": -3, "words_basis": 150.0}, "rule_type": "slop_guard.rules.passage.colon_density.ColonDensityRule"}

--- a/src/slop_guard/rules/catalog.py
+++ b/src/slop_guard/rules/catalog.py
@@ -11,6 +11,7 @@ DEFAULT_RULE_PATHS: tuple[str, ...] = (
     "slop_guard.rules.passage.rhythm.RhythmRule",
     "slop_guard.rules.passage.em_dash_density.EmDashDensityRule",
     "slop_guard.rules.sentence.contrast_pair.ContrastPairRule",
+    "slop_guard.rules.sentence.faux_deepness.FauxDeepnessRule",
     "slop_guard.rules.sentence.intrasentence_keyword_bold.IntrasentenceKeywordBoldRule",
     "slop_guard.rules.sentence.setup_resolution.SetupResolutionRule",
     "slop_guard.rules.passage.colon_density.ColonDensityRule",

--- a/src/slop_guard/rules/sentence/__init__.py
+++ b/src/slop_guard/rules/sentence/__init__.py
@@ -2,6 +2,7 @@
 
 from .ai_disclosure import AIDisclosureRule, AIDisclosureRuleConfig
 from .contrast_pair import ContrastPairRule, ContrastPairRuleConfig
+from .faux_deepness import FauxDeepnessRule, FauxDeepnessRuleConfig
 from .intrasentence_keyword_bold import (
     IntrasentenceKeywordBoldRule,
     IntrasentenceKeywordBoldRuleConfig,
@@ -18,6 +19,8 @@ __all__ = [
     "AIDisclosureRuleConfig",
     "ContrastPairRule",
     "ContrastPairRuleConfig",
+    "FauxDeepnessRule",
+    "FauxDeepnessRuleConfig",
     "IntrasentenceKeywordBoldRule",
     "IntrasentenceKeywordBoldRuleConfig",
     "PithyFragmentRule",

--- a/src/slop_guard/rules/sentence/faux_deepness.py
+++ b/src/slop_guard/rules/sentence/faux_deepness.py
@@ -1,0 +1,426 @@
+"""Detect faux-deep negations of ordinary metaphorical predicates.
+
+Objective: Catch prose that tries to sound profound by denying familiar
+metaphors, usually in stacked sentences such as "Silence does not settle" or
+"A truth does not land."
+
+Example Rule Violations:
+    - "Silence does not "settle"."
+      Negates an ordinary metaphor for an abstract subject.
+    - "Words do not hang in the air. History does not press."
+      Stacks multiple abstract negations as a depth effect.
+
+Example Non-Violations:
+    - "The paint does not settle evenly in cold rooms."
+      Concrete subject and concrete predicate use.
+    - "The team waited in silence while the room settled."
+      Uses the metaphor directly instead of denying it for effect.
+
+Severity: Low per sentence, medium when repeated in one passage.
+
+Notes: This is a precision-biased pattern rule, not semantic analysis. It
+requires an abstract subject and either a short quoted predicate or a known
+metaphorical predicate from the offline lexicon.
+"""
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import (
+    clamp_int,
+    fit_count_cap_contrastive,
+    fit_penalty_contrastive,
+    fit_threshold_high_contrastive,
+    percentile_ceil,
+)
+
+_ABSTRACT_SUBJECTS: tuple[str, ...] = (
+    "absence",
+    "beauty",
+    "belief",
+    "belonging",
+    "certainty",
+    "chaos",
+    "clarity",
+    "conscience",
+    "death",
+    "desire",
+    "doubt",
+    "faith",
+    "fear",
+    "grief",
+    "history",
+    "hope",
+    "identity",
+    "knowledge",
+    "language",
+    "loneliness",
+    "love",
+    "memory",
+    "meaning",
+    "mercy",
+    "pain",
+    "presence",
+    "regret",
+    "silence",
+    "time",
+    "truth",
+    "truths",
+    "violence",
+    "words",
+    "wound",
+    "wounds",
+)
+_METAPHOR_PREDICATES: tuple[str, ...] = (
+    "ache",
+    "aches",
+    "arrive",
+    "arrives",
+    "bleed",
+    "bleeds",
+    "bloom",
+    "blooms",
+    "breathe",
+    "breathes",
+    "burn",
+    "burns",
+    "carry",
+    "carries",
+    "close",
+    "closes",
+    "drift",
+    "drifts",
+    "echo",
+    "echoes",
+    "float",
+    "floats",
+    "hang",
+    "hang in the air",
+    "hangs",
+    "hangs in the air",
+    "haunt",
+    "haunts",
+    "hold",
+    "holds",
+    "land",
+    "lands",
+    "move",
+    "moves",
+    "open",
+    "opens",
+    "press",
+    "presses",
+    "remember",
+    "remembers",
+    "settle",
+    "settles",
+    "sing",
+    "sings",
+    "sit",
+    "sit in the room",
+    "sits",
+    "sits in the room",
+    "sleep",
+    "sleeps",
+    "speak",
+    "speaks",
+    "stare back",
+    "stares back",
+    "wait",
+    "waits",
+    "whisper",
+    "whispers",
+)
+_METAPHOR_HEADS: frozenset[str] = frozenset(
+    predicate.split()[0] for predicate in _METAPHOR_PREDICATES
+)
+_SUBJECT_ALT = "|".join(re.escape(subject) for subject in _ABSTRACT_SUBJECTS)
+_PREDICATE_ALT = "|".join(
+    re.escape(predicate).replace(r"\ ", r"\s+")
+    for predicate in sorted(
+        _METAPHOR_PREDICATES,
+        key=lambda predicate: len(predicate),
+        reverse=True,
+    )
+)
+_DETERMINER_RE = (
+    r"(?:(?:a|an|the|this|that|these|those|our|their|its|his|her|my|your)\s+)?"
+)
+_SUBJECT_RE = rf"{_DETERMINER_RE}(?:[a-z][a-z'-]*\s+){{0,2}}(?:{_SUBJECT_ALT})"
+_NEGATION_RE = (
+    r"(?:"
+    r"(?:does|do|did|can|could|will|would|should)\s+not|"
+    r"doesn't|don't|didn't|cannot|can't|won't|wouldn't|shouldn't|never"
+    r")"
+)
+_QUOTED_PREDICATE_RE = re.compile(
+    rf"(?<!\w)(?P<subject>{_SUBJECT_RE})\s+"
+    rf"(?P<negation>{_NEGATION_RE})\s+"
+    r"(?P<quote>[\"'“‘])(?P<predicate>[A-Za-z][A-Za-z\s'.,-]{0,80}?)[\"'”’]",
+    re.IGNORECASE,
+)
+_UNQUOTED_PREDICATE_RE = re.compile(
+    rf"(?<!\w)(?P<subject>{_SUBJECT_RE})\s+"
+    rf"(?P<negation>{_NEGATION_RE})\s+"
+    rf"(?P<predicate>{_PREDICATE_ALT})(?=\b|[.!?,;:])",
+    re.IGNORECASE,
+)
+
+FauxDeepnessMatch: TypeAlias = tuple[int, int, str]
+
+
+def _normalize_predicate(predicate: str) -> str:
+    """Return a lowercase predicate with quote punctuation stripped.
+
+    Args:
+        predicate: Raw predicate text captured after a negated auxiliary.
+
+    Returns:
+        A whitespace-normalized predicate string.
+    """
+    stripped = predicate.strip(" \t\r\n\"'“”‘’.,;:!?")
+    return " ".join(stripped.casefold().split())
+
+
+def _looks_like_metaphor_predicate(predicate: str) -> bool:
+    """Return whether a quoted predicate belongs to the metaphor lexicon.
+
+    Args:
+        predicate: Raw predicate text inside quote marks.
+
+    Returns:
+        ``True`` when the predicate is a known phrase or starts with a known
+        metaphor head verb.
+    """
+    normalized = _normalize_predicate(predicate)
+    if normalized in _METAPHOR_PREDICATES:
+        return True
+    first_word = normalized.split(" ", 1)[0] if normalized else ""
+    return first_word in _METAPHOR_HEADS
+
+
+def _collect_faux_deepness_matches(text: str) -> tuple[FauxDeepnessMatch, ...]:
+    """Return ordered faux-deepness matches detected in ``text``.
+
+    Args:
+        text: Source text to scan, usually with Markdown code spans masked.
+
+    Returns:
+        Ordered match tuples containing character offsets and matched snippets.
+    """
+    matches: list[FauxDeepnessMatch] = []
+    seen_spans: set[tuple[int, int]] = set()
+
+    for match in _QUOTED_PREDICATE_RE.finditer(text):
+        if not _looks_like_metaphor_predicate(match.group("predicate")):
+            continue
+        span = (match.start(), match.end())
+        seen_spans.add(span)
+        matches.append((span[0], span[1], match.group(0).strip()))
+
+    for match in _UNQUOTED_PREDICATE_RE.finditer(text):
+        span = (match.start(), match.end())
+        if span in seen_spans:
+            continue
+        matches.append((span[0], span[1], match.group(0).strip()))
+
+    matches.sort(key=lambda item: (item[0], item[1], item[2]))
+    return tuple(matches)
+
+
+def _faux_deepness_advice(snippet: str) -> str:
+    """Return rewrite guidance for one faux-deepness match.
+
+    Args:
+        snippet: Exact matched negation snippet.
+
+    Returns:
+        A rewrite instruction for the matched pattern.
+    """
+    return (
+        f"Rewrite '{snippet}' as the concrete claim; do not deny a familiar "
+        "metaphor to create depth."
+    )
+
+
+def _faux_deepness_summary_advice(match_count: int) -> str:
+    """Return aggregate advice for repeated faux-deepness matches.
+
+    Args:
+        match_count: Total number of detected faux-deepness matches.
+
+    Returns:
+        A summary advice line for a repeated pattern.
+    """
+    return (
+        f"{match_count} faux-deepness negations - stop stacking abstract "
+        "subjects with denied metaphors; replace at least one with a concrete "
+        "claim."
+    )
+
+
+@dataclass
+class FauxDeepnessRuleConfig(RuleConfig):
+    """Config for faux-deepness detection and recording limits."""
+
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per recorded abstract negation of a familiar "
+                "metaphorical predicate."
+            )
+        }
+    )
+    record_cap: int = field(
+        metadata={
+            "description": (
+                "Maximum number of faux-deepness matches recorded as "
+                "individual violations in a single pass."
+            )
+        }
+    )
+    advice_min: int = field(
+        metadata={
+            "description": (
+                "Threshold on the total faux-deepness match count at or above "
+                "which a summary advice line is emitted."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each faux-deepness violation."
+            )
+        }
+    )
+
+
+class FauxDeepnessRule(Rule[FauxDeepnessRuleConfig]):
+    """Detect negated metaphorical abstractions posing as depth."""
+
+    name = "faux_deepness"
+    count_key = "faux_deepness"
+    level = RuleLevel.SENTENCE
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger faux-deepness matches."""
+        return [
+            'Silence does not "settle".',
+            "Words do not hang in the air. History does not press.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid faux-deepness matches."""
+        return [
+            "The paint does not settle evenly in cold rooms.",
+            "The team waited in silence while the room settled.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Apply faux-deepness detection and aggregate advice."""
+        matches = _collect_faux_deepness_matches(
+            document.text_with_markdown_code_masked
+        )
+        violations: list[Violation] = []
+        advice: list[str] = []
+
+        for start, end, _masked_snippet in matches[: self.config.record_cap]:
+            snippet = document.text[start:end].strip()
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match=snippet,
+                    context=context_around(
+                        document.text,
+                        start,
+                        end,
+                        width=self.config.context_window_chars,
+                    ),
+                    penalty=self.config.penalty,
+                    start=start,
+                    end=end,
+                )
+            )
+            advice.append(_faux_deepness_advice(snippet))
+
+        if len(matches) >= self.config.advice_min:
+            advice.append(_faux_deepness_summary_advice(len(matches)))
+
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)} if violations else {},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> FauxDeepnessRuleConfig:
+        """Fit match-driven caps and penalties from corpus counts."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        positive_counts = [
+            len(_collect_faux_deepness_matches(sample)) for sample in positive_samples
+        ]
+        negative_counts = [
+            len(_collect_faux_deepness_matches(sample)) for sample in negative_samples
+        ]
+        positive_matches = sum(1 for count in positive_counts if count > 0)
+        negative_matches = sum(1 for count in negative_counts if count > 0)
+        positive_nonzero_counts = [count for count in positive_counts if count > 0]
+        negative_nonzero_counts = [count for count in negative_counts if count > 0]
+
+        record_cap = fit_count_cap_contrastive(
+            default_value=clamp_int(
+                percentile_ceil(positive_nonzero_counts, 0.90), 1, 64
+            )
+            if positive_nonzero_counts
+            else self.config.record_cap,
+            positive_values=positive_nonzero_counts,
+            negative_values=negative_nonzero_counts,
+            lower=1,
+            upper=64,
+            positive_quantile=0.90,
+            negative_quantile=0.90,
+            blend_pivot=20.0,
+        )
+        advice_min = clamp_int(
+            math.ceil(
+                fit_threshold_high_contrastive(
+                    default_value=float(
+                        clamp_int(percentile_ceil(positive_counts, 0.75), 1, 64)
+                    ),
+                    positive_values=positive_counts,
+                    negative_values=negative_counts,
+                    lower=1.0,
+                    upper=64.0,
+                    positive_quantile=0.75,
+                    negative_quantile=0.25,
+                    blend_pivot=16.0,
+                    match_mode="ge",
+                )
+            ),
+            1,
+            64,
+        )
+
+        return FauxDeepnessRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            record_cap=record_cap,
+            advice_min=advice_min,
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/scoring.py
+++ b/src/slop_guard/scoring.py
@@ -19,6 +19,7 @@ _COUNT_KEYS: tuple[str, ...] = (
     "rhythm",
     "em_dash",
     "contrast_pairs",
+    "faux_deepness",
     "intrasentence_keyword_bold",
     "setup_resolution",
     "colon_density",

--- a/tests/fixtures/faux_deepness.jsonl
+++ b/tests/fixtures/faux_deepness.jsonl
@@ -1,0 +1,20 @@
+{"text": "Silence does not \"settle\". Words do not \"hang in the air\". Knowledge does not \"sit in the room\". History does not \"press\". A truth does not \"land\".", "expected_matches": 5, "label": 0}
+{"text": "Silence doesn't \"settle\"; it waits for the reader to mistake vagueness for depth.", "expected_matches": 1, "label": 0}
+{"text": "Words do not hang in the air; they supposedly circle the room until someone confesses.", "expected_matches": 1, "label": 0}
+{"text": "Knowledge does not sit in the room. It watches from the corner like a verdict.", "expected_matches": 1, "label": 0}
+{"text": "History does not press. Memory does not hold. The paragraph calls that insight.", "expected_matches": 2, "label": 0}
+{"text": "A truth does not land because landing would make it too ordinary.", "expected_matches": 1, "label": 0}
+{"text": "Grief does not \"arrive\". Love does not \"breathe\". Both lines posture as revelation.", "expected_matches": 2, "label": 0}
+{"text": "Time never waits. Absence never sleeps. The cadence performs depth without adding a claim.", "expected_matches": 2, "label": 0}
+{"text": "Belonging cannot \"bloom\". Certainty cannot \"hold\". The negatives do the decoration.", "expected_matches": 2, "label": 0}
+{"text": "The old wound does not whisper; the sentence only borrows pressure from metaphor.", "expected_matches": 1, "label": 0}
+{"text": "Our shared silence will not \"open\" no matter how long the paragraph stares at it.", "expected_matches": 1, "label": 0}
+{"text": "Meaning would not \"carry\" us; it would stand nearby and refuse the obvious verb.", "expected_matches": 1, "label": 0}
+{"text": "The paint does not settle evenly in cold rooms, so the second coat needs more time.", "expected_matches": 0, "label": 1}
+{"text": "The invoice does not land until Friday because the vendor batch runs overnight.", "expected_matches": 0, "label": 1}
+{"text": "The team waited in silence while the room settled after the announcement.", "expected_matches": 0, "label": 1}
+{"text": "Use `Silence does not \"settle\".` as a bad example in the guide, then explain the rule plainly.", "expected_matches": 0, "label": 1}
+{"text": "```text\nWords do not \"hang in the air\".\n```\nOutside the code block, the document describes the fixture format.", "expected_matches": 0, "label": 1}
+{"text": "The words on the sign do not hang from wires; each letter is painted directly on metal.", "expected_matches": 0, "label": 1}
+{"text": "Truths don't \"land\" in this passage; they drift until the ending pretends to resolve them.", "expected_matches": 1, "label": 0}
+{"text": "Desire did not \"burn\". Fear did not \"move\". Doubt did not \"speak\".", "expected_matches": 3, "label": 0}

--- a/tests/test_faux_deepness_rule.py
+++ b/tests/test_faux_deepness_rule.py
@@ -1,0 +1,110 @@
+"""Regression tests for faux-deepness detection."""
+
+import json
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from slop_guard.config import DEFAULT_HYPERPARAMETERS
+from slop_guard.document import AnalysisDocument
+from slop_guard.rules.sentence import FauxDeepnessRule, FauxDeepnessRuleConfig
+
+FixtureRow: TypeAlias = dict[str, Any]
+
+_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "faux_deepness.jsonl"
+
+
+def _build_rule() -> FauxDeepnessRule:
+    """Construct the default faux-deepness rule used in the pipeline."""
+    return FauxDeepnessRule(
+        FauxDeepnessRuleConfig(
+            penalty=DEFAULT_HYPERPARAMETERS.faux_deepness_penalty,
+            record_cap=DEFAULT_HYPERPARAMETERS.faux_deepness_record_cap,
+            advice_min=DEFAULT_HYPERPARAMETERS.faux_deepness_advice_min,
+            context_window_chars=DEFAULT_HYPERPARAMETERS.context_window_chars,
+        )
+    )
+
+
+def _load_fixture_rows() -> list[FixtureRow]:
+    """Load faux-deepness fixture rows from JSONL."""
+    rows: list[FixtureRow] = []
+    for line in _FIXTURE_PATH.read_text(encoding="utf-8").splitlines():
+        payload = json.loads(line)
+        if not isinstance(payload, dict):
+            raise AssertionError("faux-deepness fixture rows must be objects")
+        rows.append(payload)
+    return rows
+
+
+def test_faux_deepness_counts_quoted_and_unquoted_stack() -> None:
+    """The rule should catch the motivating quoted and unquoted negations."""
+    rule = _build_rule()
+    text = (
+        'Silence does not "settle". '
+        'Words do not "hang in the air". '
+        'Knowledge does not "sit in the room". '
+        'History does not "press". '
+        'A truth does not "land".'
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.count_deltas == {"faux_deepness": 5}
+    assert [violation.match for violation in result.violations] == [
+        'Silence does not "settle"',
+        'Words do not "hang in the air"',
+        'Knowledge does not "sit in the room"',
+        'History does not "press"',
+        'A truth does not "land"',
+    ]
+    assert any("5 faux-deepness negations" in item for item in result.advice)
+
+
+def test_faux_deepness_fixture_rows_have_expected_match_counts() -> None:
+    """The 20-row fixture should cover matched and non-matched variants."""
+    rule = _build_rule()
+    rows = _load_fixture_rows()
+
+    assert len(rows) == 20
+
+    for row in rows:
+        text = row["text"]
+        expected_matches = row["expected_matches"]
+        if not isinstance(text, str) or not isinstance(expected_matches, int):
+            raise AssertionError("fixture rows require text and expected_matches")
+
+        result = rule.forward(AnalysisDocument.from_text(text))
+
+        assert len(result.violations) == expected_matches, text
+
+
+def test_faux_deepness_ignores_concrete_literal_negations() -> None:
+    """Concrete subjects using the same verbs should not trigger the rule."""
+    rule = _build_rule()
+    text = (
+        "The paint does not settle evenly in cold rooms. "
+        "The invoice does not land until Friday. "
+        "The team waited in silence while the room settled."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+    assert result.count_deltas == {}
+
+
+def test_faux_deepness_ignores_markdown_code_spans() -> None:
+    """Markdown code examples should be masked before matching."""
+    rule = _build_rule()
+    text = (
+        'Use `Silence does not "settle".` as an inline example.\n\n'
+        "```text\n"
+        'Words do not "hang in the air".\n'
+        "```\n\n"
+        "The surrounding explanation is plain prose with no faux-deepness hit."
+    )
+
+    result = rule.forward(AnalysisDocument.from_text(text))
+
+    assert result.violations == []
+    assert result.count_deltas == {}

--- a/tests/test_rule_fit_learning.py
+++ b/tests/test_rule_fit_learning.py
@@ -23,6 +23,7 @@ from slop_guard.rules.passage import (
 from slop_guard.rules.sentence import (
     AIDisclosureRule,
     ContrastPairRule,
+    FauxDeepnessRule,
     PithyFragmentRule,
     PlaceholderRule,
     SetupResolutionRule,
@@ -128,6 +129,14 @@ FIT_CASES: tuple[FitCase, ...] = (
         [
             "focus, not frenzy.",
             "clarity, not complexity.",
+        ],
+    ),
+    (
+        FauxDeepnessRule,
+        "penalty",
+        [
+            'Silence does not "settle". Words do not "hang in the air".',
+            'Memory does not "hold". Truth does not "land".',
         ],
     ),
     (

--- a/zensical.toml
+++ b/zensical.toml
@@ -25,6 +25,7 @@ nav = [
       { "AI Disclosure" = "rules/ai-disclosure.md" },
       { "Placeholder" = "rules/placeholder.md" },
       { "Contrast Pair" = "rules/contrast-pair.md" },
+      { "Faux Deepness" = "rules/faux-deepness.md" },
       { "Intrasentence Keyword Bold" = "rules/intrasentence-keyword-bold.md" },
       { "Setup Resolution" = "rules/setup-resolution.md" },
       { "Pithy Fragment" = "rules/pithy-fragment.md" },


### PR DESCRIPTION
## Description

Adds a default `faux_deepness` sentence rule that detects abstract subjects paired with negated metaphor predicates. The rule uses an offline subject and predicate lexicon, records concrete spans, masks Markdown code spans, supports rule fitting, and emits summary advice when multiple hits appear in one passage.

## Why?

Models sometimes simulate profundity by negating ordinary metaphors instead of making a concrete claim. This gives slop-guard a local signal for that pattern without adding model calls or network dependencies, and keeps the signal configurable alongside the existing sentence rules.

## Usage / Demonstration

```bash
uv run sg --counts 'Silence does not "settle". Words do not "hang in the air". Knowledge does not "sit in the room". History does not "press". A truth does not "land".'
```

```text
<text:1>: 0/100 [saturated] (27 words) !!!  (rhythm=1 faux_deepness=5)
```

The test fixture at `tests/fixtures/faux_deepness.jsonl` includes 20 rows with matched and non-matched variants, including quoted predicates, unquoted predicates, contractions, `never` forms, concrete-subject non-matches, and Markdown code-span non-matches.

## Verification

- `uv run pytest tests/test_faux_deepness_rule.py tests/test_rule_framework.py::test_rule_examples_match_rule_forward_behavior tests/test_rule_fit_learning.py::test_all_default_rules_override_base_fit_impl tests/test_rule_fit_learning.py::test_fit_updates_rule_hyperparameters -q`
- `make check`
- `make docs-check`
- `uv run sg -v -t 60 docs/rules/faux-deepness.md docs/rules/index.md` was also run. It reports expected failures because generated rule pages contain intentional violation examples and repeated HTML card markup; `make docs-check` excludes `docs/rules/*` and passed.

## Issues

None.
