### PR TITLE
Add writing-quality rule pipeline with category-tagged violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@
 
 A rule-based prose linter that scores text 0--100 for formulaic AI writing patterns. No LLM judge, no API calls. Purely programmatic.
 
-The default pipeline loads 23 configurable rules backed by 200+ literal and structural heuristics. It returns a numeric score, a band label, specific violations with surrounding context, and concrete advice for each hit.
+slop-guard ships two rule presets:
+
+- **`ai_slop`** (the default) — 24 rules targeting model-generated tells: stock hype words, boilerplate phrases, assistant tone markers, structural patterns, and rhythm tics.
+- **`writing_quality`** — 14 opinionated style rules: qualifier words, verbose phrases, pretentious vocabulary with replacements, redundant pairs, clichés, foreign/Latin phrases, ecstatic adjectives, throat-clearing, over-explanation, two-tier passive voice, long sentences, exclamation density, emoji in prose, and narrative-poetic Markdown headings.
+
+Default-only output is unchanged from earlier releases. When the writing-quality preset is loaded (alone or alongside the default), each violation gains a `category` field and the result gains a `category_counts` aggregation. See [Rule presets](#rule-presets) for how to choose between them.
 
 ## Add to Your Agent
 
 Both clients use the same MCP command: `uvx slop-guard`.
 If you want a custom rule JSONL, append `-c /path/to/config.jsonl`.
+The default rule set is the `ai_slop` preset; pass `-c` with the writing-quality JSONL to opt into those checks. See [Rule presets](#rule-presets) for the bundled paths.
 
 ### Claude Code
 
@@ -49,6 +55,103 @@ args = ["slop-guard"]
 ```
 
 If you want a fixed release, pin it in `args`, for example: `["slop-guard==0.4.1"]`.
+
+## Rule presets
+
+slop-guard ships two packaged JSONL rule files. Pick one with the `-c` flag (CLI) or the `args` array (MCP).
+
+| Preset | Bundled path | What it catches |
+|--------|--------------|-----------------|
+| `ai_slop` (default) | `slop_guard/rules/assets/default.jsonl` | Model-generated tells, structural patterns, rhythm tics |
+| `writing_quality` | `slop_guard/rules/assets/writing_quality.jsonl` | Style problems: clichés, redundancy, passive voice, verbose phrasing |
+
+The bundled paths sit inside the installed package. To resolve the absolute path on your system, use `importlib.resources`:
+
+```bash
+WQ_PATH=$(python -c 'from importlib.resources import files; print(files("slop_guard.rules").joinpath("assets/writing_quality.jsonl"))')
+```
+
+### CLI examples
+
+Run the default `ai_slop` rules:
+
+```bash
+sg draft.md
+# => draft.md: 72/100 [light] (1843 words) *
+```
+
+Run the `writing_quality` rules instead:
+
+```bash
+sg -c "$WQ_PATH" draft.md
+# => draft.md: 65/100 [light] (1843 words) *
+```
+
+Run both presets together by concatenating the JSONL files into one config:
+
+```bash
+DEFAULT_PATH=$(python -c 'from importlib.resources import files; print(files("slop_guard.rules").joinpath("assets/default.jsonl"))')
+cat "$DEFAULT_PATH" "$WQ_PATH" > all_rules.jsonl
+sg -c all_rules.jsonl draft.md
+```
+
+### MCP examples
+
+The MCP server reads the same `-c` flag from its launch arguments. Configure two server entries when you want both presets available to an agent — one with the default rules and one with the writing-quality rules.
+
+For Claude Code in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "slop-guard": {
+      "command": "uvx",
+      "args": ["slop-guard"]
+    },
+    "slop-guard-writing-quality": {
+      "command": "uvx",
+      "args": [
+        "--with",
+        "slop-guard",
+        "sh",
+        "-c",
+        "uvx slop-guard -c $(python -c 'from importlib.resources import files; print(files(\"slop_guard.rules\").joinpath(\"assets/writing_quality.jsonl\"))')"
+      ]
+    }
+  }
+}
+```
+
+A simpler approach is to copy the writing-quality JSONL out of the package once and reference it by path:
+
+```bash
+python -c 'from importlib.resources import files; print(files("slop_guard.rules").joinpath("assets/writing_quality.jsonl").read_text())' > ~/.config/slop-guard/writing_quality.jsonl
+```
+
+Then point your MCP entry at that file:
+
+```json
+{
+  "mcpServers": {
+    "slop-guard-writing-quality": {
+      "command": "uvx",
+      "args": ["slop-guard", "-c", "~/.config/slop-guard/writing_quality.jsonl"]
+    }
+  }
+}
+```
+
+Codex uses the same pattern in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.slop-guard]
+command = "uvx"
+args = ["slop-guard"]
+
+[mcp_servers.slop-guard-writing-quality]
+command = "uvx"
+args = ["slop-guard", "-c", "/Users/you/.config/slop-guard/writing_quality.jsonl"]
+```
 
 ## CLI
 
@@ -236,9 +339,13 @@ make verify-wheel
 
 ## What it catches
 
-The default rules cover stock hype words and boilerplate phrases, assistant tone markers, unattributed weasel phrasing, AI self-disclosure, placeholder text, bullet/blockquote/horizontal-rule-heavy Markdown structures, sentence and paragraph rhythm, and em dash or colon overuse.
+The default `ai_slop` preset covers stock hype words and boilerplate phrases, assistant tone markers, unattributed weasel phrasing, AI self-disclosure, placeholder text, bullet/blockquote/horizontal-rule-heavy Markdown structures, sentence and paragraph rhythm, and em dash or colon overuse.
 
-They also flag contrast/setup-resolution tells, pithy fragments, repeated 4-8 word phrases, copula chains, extreme long sentences, aphoristic closers, and uneven paragraph cadence.
+It also flags contrast/setup-resolution tells, pithy fragments, repeated 4-8 word phrases, copula chains, extreme long sentences, aphoristic closers, and uneven paragraph cadence.
+
+The `writing_quality` preset (opt-in via `-c`) targets style instead of AI fingerprints. At the word level it flags weakening qualifiers, pretentious vocabulary, and ecstatic adjectives. At the phrase and sentence level it covers verbose phrasing, redundant pairs, clichés, foreign and Latin phrases, throat-clearing, over-explanation, and two-tier passive voice. At the passage level it adds long sentences, exclamation density, emoji in prose, and `narrative-poetic` Markdown headings.
+
+Several rules ship explicit replacements so the advice names the substitution. The advice for the wordy phrase you would replace with `to` is `Replace 'in order to' with 'to'.`, and the same shape applies to `utilize` → `use`, `methodology` → `method`, and `per se` → `by itself`. See [Rule presets](#rule-presets) for how to enable the preset.
 
 Texts under 10 words are skipped and return a clean `100`.
 
@@ -259,17 +366,26 @@ Otherwise scoring uses exponential decay: `score = 100 * exp(-lambda * density)`
 CLI `--json` output and MCP tool responses share this structure:
 
 ```
-source         CLI JSON only; raw inline/stdin text or full file path
-score          0-100 integer
-band           "clean" / "light" / "moderate" / "heavy" / "saturated"
-word_count     integer
-violations     array of {type, rule, match, context, penalty, start, end}
-counts         per-category violation counts
-total_penalty  sum of all penalty values
-weighted_sum   after concentration multiplier
-density        weighted_sum per 1000 words
-advice         array of advice strings, one per distinct issue
+source           CLI JSON only; raw inline/stdin text or full file path
+score            0-100 integer
+band             "clean" / "light" / "moderate" / "heavy" / "saturated"
+word_count       integer
+violations       array of {type, rule, match, context, penalty, start, end}
+counts           per-rule violation counts (keyed by rule count_key)
+total_penalty    sum of all penalty values
+weighted_sum     after concentration multiplier
+density          weighted_sum per 1000 words
+advice           array of advice strings, one per distinct issue
 ```
+
+When the active pipeline includes any non-default category — typically when you load `writing_quality.jsonl` via `-c` — two extra fields appear:
+
+```
+violations[].category  "ai_slop" or "writing_quality"
+category_counts        per-category violation counts (e.g. {"writing_quality": 3})
+```
+
+The default `ai_slop`-only pipeline produces the original schema with neither field, so existing consumers are unaffected.
 
 MCP tool responses omit `source`, because the tool transport already carries the
 input parameter.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -39,6 +39,47 @@ Register the server with Claude Code by pointing `mcp add` at `uvx slop-guard`, 
 }
 ```
 
+## Choose a rule preset
+
+The MCP server reads the same `-c` flag from its launch arguments that the CLI does. The default rule set is the `ai_slop` preset; pass `-c` with the bundled `writing_quality.jsonl` to opt into the opinionated style checks. Configure two MCP entries when you want both presets available to the agent.
+
+Resolve the bundled writing-quality path and copy it somewhere stable:
+
+```bash
+python -c 'from importlib.resources import files; print(files("slop_guard.rules").joinpath("assets/writing_quality.jsonl").read_text())' > ~/.config/slop-guard/writing_quality.jsonl
+```
+
+Codex `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.slop-guard]
+command = "uvx"
+args = ["slop-guard"]
+
+[mcp_servers.slop-guard-writing-quality]
+command = "uvx"
+args = ["slop-guard", "-c", "/Users/you/.config/slop-guard/writing_quality.jsonl"]
+```
+
+Claude Code `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "slop-guard": {
+      "command": "uvx",
+      "args": ["slop-guard"]
+    },
+    "slop-guard-writing-quality": {
+      "command": "uvx",
+      "args": ["slop-guard", "-c", "/Users/you/.config/slop-guard/writing_quality.jsonl"]
+    }
+  }
+}
+```
+
+Each violation the MCP tool returns carries a `category` field (`"ai_slop"` or `"writing_quality"`) that matches the preset that registered the rule, and `category_counts` aggregates violations per category.
+
 ## Pin a release
 
 If an automation or team workflow needs a fixed package version, pin it in the command arguments:

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -39,6 +39,40 @@ sg -t 60 README.md docs/**/*.md
 
 Add `-v` to inspect individual hits, or `-j` when you want JSON output for scripts.
 
+## Pick a rule preset
+
+slop-guard ships two rule presets. The default is `ai_slop` (the rules that target model-generated tells). Pass `-c` with the bundled `writing_quality.jsonl` when you want the opinionated style checks instead.
+
+Resolve the bundled paths once:
+
+```bash
+DEFAULT_PATH=$(python -c 'from importlib.resources import files; print(files("slop_guard.rules").joinpath("assets/default.jsonl"))')
+WQ_PATH=$(python -c 'from importlib.resources import files; print(files("slop_guard.rules").joinpath("assets/writing_quality.jsonl"))')
+```
+
+Run the default `ai_slop` preset:
+
+```bash
+sg README.md
+# equivalent to:
+sg -c "$DEFAULT_PATH" README.md
+```
+
+Run the `writing_quality` preset:
+
+```bash
+sg -c "$WQ_PATH" README.md
+```
+
+Run both presets in one pass by concatenating the JSONLs:
+
+```bash
+cat "$DEFAULT_PATH" "$WQ_PATH" > all_rules.jsonl
+sg -c all_rules.jsonl README.md
+```
+
+Each violation in the JSON output carries a `category` field set to the preset that registered the rule, and the result includes `category_counts` aggregating violations per category.
+
 ## Work from source
 
 From a local checkout, `uv run` exposes the same entry points without publishing a package first:

--- a/docs/rules/cliche-phrase.md
+++ b/docs/rules/cliche-phrase.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Cliche Phrase
+description: Detect worn metaphorical clichés.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Cliche Phrase</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/cliche_phrase.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect worn metaphorical clichés.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ClichePhraseRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>cliche_phrase</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>cliche_phrases</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Let's think outside the box and move the needle."</code></td><td class="sg-behavior__why">Stacks two corporate clichés in one breath.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"The cache hit rate is just the tip of the iceberg."</code></td><td class="sg-behavior__why">Reaches for a cliché instead of naming the underlying issue.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"We can reduce p99 by batching writes; cache misses dominate the rest."</code></td><td class="sg-behavior__why">Concrete causes named directly.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The lock contention pattern repeats across three subsystems."</code></td><td class="sg-behavior__why">Specific observation without metaphor.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium per hit; clichés rarely add information their replacement sentence cannot.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+</div>
+
+</div>

--- a/docs/rules/ecstatic-adjective.md
+++ b/docs/rules/ecstatic-adjective.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Ecstatic Adjective
+description: Detect vague high-praise adjectives.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--word">
+  <div class="sg-rule-page__eyebrow">WORD</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Ecstatic Adjective</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/word/ecstatic_adjective.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect vague high-praise adjectives.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>EcstaticAdjectiveRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>ecstatic_adjective</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>ecstatic_adjectives</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"This is a wonderful, fantastic, mind-blowing release."</code></td><td class="sg-behavior__why">Stacked vague praise instead of any concrete property.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"An amazing improvement in throughput."</code></td><td class="sg-behavior__why">Praise without a number or named property.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Throughput rose 3.4x at the same p99 budget."</code></td><td class="sg-behavior__why">Concrete metric replaces the praise.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The release closed 12 long-standing data corruption bugs."</code></td><td class="sg-behavior__why">Names what changed without rhetorical inflation.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low per hit; cumulative use signals promotional rather than reported prose. Skips entries already covered by SlopWordRule (stunning, breathtaking, captivating).
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-1</span></div>
+</div>
+
+</div>

--- a/docs/rules/emoji-in-prose.md
+++ b/docs/rules/emoji-in-prose.md
@@ -1,0 +1,47 @@
+---
+icon: lucide/shield-check
+title: Emoji In Prose
+description: Detect emoji embedded in prose.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Emoji In Prose</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/emoji_in_prose.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect emoji embedded in prose.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>EmojiInProseRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>emoji_in_prose</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>emoji_in_prose</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"We shipped it 🚀 and the team is thrilled 🎉."</code></td><td class="sg-behavior__why">Decorative emoji punctuation in plain prose.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"We shipped it and the team is satisfied with the result."</code></td><td class="sg-behavior__why">No emoji in prose.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium per hit; emoji in prose nearly always replace a more specific written claim.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-3</span></div>
+</div>
+
+</div>

--- a/docs/rules/exclamation-density.md
+++ b/docs/rules/exclamation-density.md
@@ -1,0 +1,48 @@
+---
+icon: lucide/shield-check
+title: Exclamation Density
+description: Detect excessive exclamation marks across a passage.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Exclamation Density</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/exclamation_density.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect excessive exclamation marks across a passage.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ExclamationDensityRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>exclamation_density</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>exclamation_density</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"We shipped it! It works! Amazing!"</code></td><td class="sg-behavior__why">Three exclamations across 7 words.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"We shipped it. It works. The release closed 12 bugs."</code></td><td class="sg-behavior__why">Period-only punctuation.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium when over threshold; one violation per passage.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">density_threshold</span><span class="sg-defaults__value">1.0</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-3</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">words_basis</span><span class="sg-defaults__value">150.0</span></div>
+</div>
+
+</div>

--- a/docs/rules/foreign-phrase.md
+++ b/docs/rules/foreign-phrase.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Foreign Phrase
+description: Detect foreign and Latin phrases with plain-English equivalents.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Foreign Phrase</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/foreign_phrase.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect foreign and Latin phrases with plain-English equivalents.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ForeignPhraseRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>foreign_phrase</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>foreign_phrases</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Per se, the migration was successful."</code></td><td class="sg-behavior__why">Uses "per se" where "by itself" reads more directly.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"We need an ad hoc fix vis-a-vis the regression."</code></td><td class="sg-behavior__why">Stacks two unnecessary borrowings.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"By itself, the migration was successful."</code></td><td class="sg-behavior__why">Plain English equivalent.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"We need an improvised fix for the regression."</code></td><td class="sg-behavior__why">Direct phrasing.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low per hit; the penalty is light because some technical writing legitimately uses these terms.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-1</span></div>
+</div>
+
+</div>

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -8,7 +8,7 @@ description: Catalog of the rules that slop-guard runs on every check.
 
 `slop-guard` ships a pipeline of small, independently scored rules. Each rule targets one formulaic pattern, flags the exact matching spans, and contributes a penalty toward the final score.
 
-The default pipeline runs **24 rules** across four scopes. Open a card to read the full rule page, including example violations, default thresholds, and a link to the source file.
+The library lists **38 rules** across four scopes — **24** in the default `ai_slop` pipeline and **14** in the opt-in `writing_quality` preset. Open a card to read the full rule page, including example violations, default thresholds, and a link to the source file.
 
 ## Word rules
 
@@ -19,6 +19,24 @@ Single-token checks. These are the cheapest rules and fire on individual AI-asso
   <a class="sg-rule-card__link" href="./slop-word/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Slop Word</span></div>
     <p class="sg-rule-card__summary">Detect overused AI-associated slop words.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./qualifier-word/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Qualifier Word</span></div>
+    <p class="sg-rule-card__summary">Detect weakening qualifier words and phrases.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./pretentious-word/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Pretentious Word</span></div>
+    <p class="sg-rule-card__summary">Detect pretentious vocabulary with concrete plain-English replacements.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./ecstatic-adjective/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Ecstatic Adjective</span></div>
+    <p class="sg-rule-card__summary">Detect vague high-praise adjectives.</p>
   </a>
 </div>
 </div>
@@ -82,6 +100,48 @@ One sentence at a time. Catches canned phrases, disclosures, tone markers, and t
     <p class="sg-rule-card__summary">Detect short evaluative pivot fragments.</p>
   </a>
 </div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./verbose-phrase/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Verbose Phrase</span></div>
+    <p class="sg-rule-card__summary">Detect wordy phrases with shorter equivalents.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./throat-clearing/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Throat Clearing</span></div>
+    <p class="sg-rule-card__summary">Detect throat-clearing phrases that delay the actual point.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./over-explanation/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Over Explanation</span></div>
+    <p class="sg-rule-card__summary">Detect over-explanation phrases that announce the obvious.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./redundant-pair/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Redundant Pair</span></div>
+    <p class="sg-rule-card__summary">Detect redundant word pairs where one word implies the other.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./cliche-phrase/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Cliche Phrase</span></div>
+    <p class="sg-rule-card__summary">Detect worn metaphorical clichés.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./foreign-phrase/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Foreign Phrase</span></div>
+    <p class="sg-rule-card__summary">Detect foreign and Latin phrases with plain-English equivalents.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./passive-voice/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Passive Voice</span></div>
+    <p class="sg-rule-card__summary">Detect passive voice constructions with a two-tier confidence model.</p>
+  </a>
+</div>
 </div>
 
 ## Paragraph rules
@@ -117,6 +177,12 @@ Adjacent-line structure. Catches bullet runs, blockquotes, horizontal rules, and
   <a class="sg-rule-card__link" href="./horizontal-rule-overuse/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Horizontal Rule Overuse</span></div>
     <p class="sg-rule-card__summary">Detect overuse of horizontal rule separators.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./narrative-heading/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Narrative Heading</span></div>
+    <p class="sg-rule-card__summary">Detect narrative-poetic Markdown headings.</p>
   </a>
 </div>
 </div>
@@ -178,6 +244,24 @@ Whole-document signals. Catches rhythm, density, and repetition across the full 
   <a class="sg-rule-card__link" href="./paragraph-cv/">
     <div class="sg-rule-card__head"><span class="sg-rule-card__title">Paragraph CV</span></div>
     <p class="sg-rule-card__summary">Detect suspiciously uniform paragraph lengths.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./long-sentence/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Long Sentence</span></div>
+    <p class="sg-rule-card__summary">Detect moderately long sentences with a per-document cap.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./exclamation-density/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Exclamation Density</span></div>
+    <p class="sg-rule-card__summary">Detect excessive exclamation marks across a passage.</p>
+  </a>
+</div>
+<div class="sg-rule-card">
+  <a class="sg-rule-card__link" href="./emoji-in-prose/">
+    <div class="sg-rule-card__head"><span class="sg-rule-card__title">Emoji In Prose</span></div>
+    <p class="sg-rule-card__summary">Detect emoji embedded in prose.</p>
   </a>
 </div>
 </div>

--- a/docs/rules/long-sentence.md
+++ b/docs/rules/long-sentence.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Long Sentence
+description: Detect moderately long sentences with a per-document cap.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--passage">
+  <div class="sg-rule-page__eyebrow">PASSAGE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Long Sentence</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/passage/long_sentence.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect moderately long sentences with a per-document cap.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>LongSentenceRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>long_sentence</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>long_sentence</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">A single sentence of 45 words chaining several clauses with commas and</code></td><td class="sg-behavior__why">conjunctions instead of breaking into shorter statements.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The update shipped on Tuesday."</code></td><td class="sg-behavior__why">Short, direct sentence.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">A passage where every sentence stays under the configured threshold.</code></td><td class="sg-behavior__why"></td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium per hit, capped at ``max_hits`` so one bad section can't saturate the score on its own.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">max_hits</span><span class="sg-defaults__value">5</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">min_words</span><span class="sg-defaults__value">40</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+</div>
+
+</div>

--- a/docs/rules/narrative-heading.md
+++ b/docs/rules/narrative-heading.md
@@ -1,0 +1,51 @@
+---
+icon: lucide/shield-check
+title: Narrative Heading
+description: Detect narrative-poetic Markdown headings.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--paragraph">
+  <div class="sg-rule-page__eyebrow">PARAGRAPH</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Narrative Heading</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/paragraph/narrative_heading.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect narrative-poetic Markdown headings.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>NarrativeHeadingRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>narrative_heading</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>narrative_heading</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"## The Journey of Refactoring"</code></td><td class="sg-behavior__why"></td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"## The Art of Caching"</code></td><td class="sg-behavior__why"></td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"## The Power of Idempotence"</code></td><td class="sg-behavior__why"></td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"## Caching strategy"</code></td><td class="sg-behavior__why"></td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"## How retries work"</code></td><td class="sg-behavior__why"></td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"## Refactor plan"</code></td><td class="sg-behavior__why"></td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+High per hit; the pattern is rare in authored prose.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-4</span></div>
+</div>
+
+</div>

--- a/docs/rules/over-explanation.md
+++ b/docs/rules/over-explanation.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Over Explanation
+description: Detect over-explanation phrases that announce the obvious.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Over Explanation</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/over_explanation.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect over-explanation phrases that announce the obvious.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>OverExplanationRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>over_explanation</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>over_explanation</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Needless to say, retries should be idempotent."</code></td><td class="sg-behavior__why">Announces obviousness instead of just stating the rule.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"It is obvious that the cache hit rate matters."</code></td><td class="sg-behavior__why">Same pattern, longer.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Retries should be idempotent."</code></td><td class="sg-behavior__why">Direct statement.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Cache hit rate dropped from 92% to 41%."</code></td><td class="sg-behavior__why">Concrete claim with a number.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium per hit; almost always replaceable with the bare claim.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+</div>
+
+</div>

--- a/docs/rules/passive-voice.md
+++ b/docs/rules/passive-voice.md
@@ -1,0 +1,50 @@
+---
+icon: lucide/shield-check
+title: Passive Voice
+description: Detect passive voice constructions with a two-tier confidence model.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Passive Voice</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/passive_voice.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect passive voice constructions with a two-tier confidence model.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>PassiveVoiceRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>passive_voice</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>passive_voice</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"The migration was approved by the architecture council."</code></td><td class="sg-behavior__why">Tier 1: explicit agent makes the passive construction certain.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"The cache is invalidated. Logs are dropped. Errors are swallowed."</code></td><td class="sg-behavior__why">Tier 2: three be-verb + participle pairs trip the density gate.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The architecture council approved the migration."</code></td><td class="sg-behavior__why">Active rewrite of the same claim.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"She was born in 1962." / "The pattern is known for X."</code></td><td class="sg-behavior__why">Common false-positive idioms; participles deliberately excluded from the tier-2 list.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium per hit; passive voice often hides who did what.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">tier_two_min_hits</span><span class="sg-defaults__value">3</span></div>
+</div>
+
+</div>

--- a/docs/rules/pretentious-word.md
+++ b/docs/rules/pretentious-word.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Pretentious Word
+description: Detect pretentious vocabulary with concrete plain-English replacements.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--word">
+  <div class="sg-rule-page__eyebrow">WORD</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Pretentious Word</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/word/pretentious_word.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect pretentious vocabulary with concrete plain-English replacements.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>PretentiousWordRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>pretentious_word</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>pretentious_words</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"We will utilize a new methodology."</code></td><td class="sg-behavior__why">Uses "utilize" where "use" is shorter and clearer.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Commence the aforementioned subsequent phase."</code></td><td class="sg-behavior__why">Stacks pretentious replacements for "start", "this", and "next".</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Use the next phase of the rollout."</code></td><td class="sg-behavior__why">Plain English equivalents.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The method runs in O(n)."</code></td><td class="sg-behavior__why">Domain term used precisely; no inflated synonym.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium per hit; the replacement is usually a strict improvement.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+</div>
+
+</div>

--- a/docs/rules/qualifier-word.md
+++ b/docs/rules/qualifier-word.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Qualifier Word
+description: Detect weakening qualifier words and phrases.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--word">
+  <div class="sg-rule-page__eyebrow">WORD</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Qualifier Word</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/word/qualifier_word.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect weakening qualifier words and phrases.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>QualifierWordRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>qualifier_word</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>qualifier_words</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"The fix is very fast and quite reliable."</code></td><td class="sg-behavior__why">Stacks weakeners instead of citing concrete metrics.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"It was sort of unclear what the impact was."</code></td><td class="sg-behavior__why">Uses a multi-word qualifier in place of a definite assessment.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The patch reduced p99 latency from 400 ms to 90 ms."</code></td><td class="sg-behavior__why">Concrete measurement with no hedging.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Three retries succeeded; the fourth timed out."</code></td><td class="sg-behavior__why">Direct statement of outcome.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low per hit; cumulative penalty signals hedged or imprecise prose.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-1</span></div>
+</div>
+
+</div>

--- a/docs/rules/redundant-pair.md
+++ b/docs/rules/redundant-pair.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Redundant Pair
+description: Detect redundant word pairs where one word implies the other.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Redundant Pair</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/redundant_pair.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect redundant word pairs where one word implies the other.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>RedundantPairRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>redundant_pair</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>redundant_pairs</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"The cache was completely destroyed."</code></td><td class="sg-behavior__why">"Destroyed" already implies completeness.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"We need to revert back to the previous schema."</code></td><td class="sg-behavior__why">"Revert" already implies "back".</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The cache was destroyed."</code></td><td class="sg-behavior__why">Single, sufficient verb.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"We need to revert to the previous schema."</code></td><td class="sg-behavior__why">Concise form.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Low per hit; the redundant word is always a free deletion.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-1</span></div>
+</div>
+
+</div>

--- a/docs/rules/throat-clearing.md
+++ b/docs/rules/throat-clearing.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Throat Clearing
+description: Detect throat-clearing phrases that delay the actual point.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Throat Clearing</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/throat_clearing.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect throat-clearing phrases that delay the actual point.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>ThroatClearingRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>throat_clearing</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>throat_clearing</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"It should be pointed out that the index is unused."</code></td><td class="sg-behavior__why">Frames the claim instead of stating it.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Truth be told, the migration regressed throughput."</code></td><td class="sg-behavior__why">Performative honesty preface delays the actual finding.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The index is unused."</code></td><td class="sg-behavior__why">States the claim directly.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"The migration regressed throughput by 12%."</code></td><td class="sg-behavior__why">Direct finding with a number.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium per hit; the framing always wastes attention.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+</div>
+
+</div>

--- a/docs/rules/verbose-phrase.md
+++ b/docs/rules/verbose-phrase.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/shield-check
+title: Verbose Phrase
+description: Detect wordy phrases with shorter equivalents.
+---
+
+<div class="sg-rule-page" markdown>
+
+<header class="sg-rule-page__header sg-rule-page__header--sentence">
+  <div class="sg-rule-page__eyebrow">SENTENCE</div>
+  <div class="sg-rule-page__titlebar">
+    <h1 class="sg-rule-page__title">Verbose Phrase</h1>
+    <a class="sg-source-chip" href="https://github.com/eric-tramel/slop-guard/blob/main/src/slop_guard/rules/sentence/verbose_phrase.py"><svg class="sg-source-chip__icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.9-.39 2.88-.4.98.01 1.96.14 2.88.4 2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.77.12 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.26 5.68.41.36.78 1.06.78 2.15v3.19c0 .31.21.68.8.56 4.57-1.52 7.85-5.83 7.85-10.91C23.5 5.73 18.27.5 12 .5Z"/></svg><span>source</span></a>
+  </div>
+  <p class="sg-rule-page__lede" markdown>Detect wordy phrases with shorter equivalents.</p>
+</header>
+
+<dl class="sg-rule-meta">
+  <div class="sg-rule-meta__item"><dt>Class</dt><dd><code>VerbosePhraseRule</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Rule name</dt><dd><code>verbose_phrase</code></dd></div>
+  <div class="sg-rule-meta__item"><dt>Count key</dt><dd><code>verbose_phrases</code></dd></div>
+</dl>
+
+## Behavior
+
+<table class="sg-behavior">
+  <thead>
+    <tr><th class="sg-behavior__th-result">Result</th><th>Input text</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"We migrated in order to reduce cost."</code></td><td class="sg-behavior__why">Uses "in order to" where "to" suffices.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--flag"><td class="sg-behavior__result"><span class="sg-status sg-status--flag"><span class="sg-status__dot" aria-hidden="true"></span>Flag</span></td><td><code class="sg-behavior__input">"Due to the fact that the disk was full, writes failed."</code></td><td class="sg-behavior__why">Uses "due to the fact that" where "because" suffices.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"We migrated to reduce cost."</code></td><td class="sg-behavior__why">Uses the concise form already.</td></tr>
+    <tr class="sg-behavior__row sg-behavior__row--pass"><td class="sg-behavior__result"><span class="sg-status sg-status--pass"><span class="sg-status__dot" aria-hidden="true"></span>Pass</span></td><td><code class="sg-behavior__input">"Writes failed because the disk was full."</code></td><td class="sg-behavior__why">Uses "because" directly.</td></tr>
+  </tbody>
+</table>
+
+## Severity
+
+Medium per hit; replacements are deterministic and unambiguous.
+
+## Default configuration
+
+<div class="sg-defaults">
+  <div class="sg-defaults__item"><span class="sg-defaults__label">context_window_chars</span><span class="sg-defaults__value">60</span></div>
+  <div class="sg-defaults__item"><span class="sg-defaults__label">penalty</span><span class="sg-defaults__value">-2</span></div>
+</div>
+
+</div>

--- a/src/slop_guard/apps/cli.py
+++ b/src/slop_guard/apps/cli.py
@@ -135,7 +135,7 @@ def _analyze_text(
 ) -> SourceAnalysisPayload:
     """Run analysis and attach the source label."""
     result = analyze_text(text, hyperparameters=hyperparameters, pipeline=pipeline)
-    return SourceAnalysisPayload(
+    payload = SourceAnalysisPayload(
         score=result["score"],
         band=result["band"],
         word_count=result["word_count"],
@@ -147,6 +147,9 @@ def _analyze_text(
         advice=result["advice"],
         source=source,
     )
+    if "category_counts" in result:
+        payload["category_counts"] = result["category_counts"]
+    return payload
 
 
 def _analyze_file(

--- a/src/slop_guard/engine.py
+++ b/src/slop_guard/engine.py
@@ -34,13 +34,17 @@ def analyze_document(
     """Run all configured rules and return score, diagnostics, and advice."""
     active_pipeline = _packaged_default_pipeline() if pipeline is None else pipeline
     count_keys = getattr(active_pipeline, "count_keys", None)
+    emits_categories = bool(getattr(active_pipeline, "emits_categories", False))
 
     if document.word_count < hyperparameters.short_text_word_count:
-        return short_text_result(
+        payload = short_text_result(
             document.word_count,
             initial_counts(count_keys),
             hyperparameters,
         )
+        if emits_categories:
+            payload["category_counts"] = {}
+        return payload
 
     state = active_pipeline.forward(document)
     total_penalty = sum(violation.penalty for violation in state.violations)
@@ -57,7 +61,7 @@ def analyze_document(
     score = score_from_density(density, hyperparameters)
     band = band_for_score(score, hyperparameters)
 
-    return {
+    payload: AnalysisPayload = {
         "score": score,
         "band": band,
         "word_count": document.word_count,
@@ -65,6 +69,7 @@ def analyze_document(
             state.violations,
             document.text,
             hyperparameters.context_window_chars,
+            include_category=emits_categories,
         ),
         "counts": state.counts,
         "total_penalty": total_penalty,
@@ -72,6 +77,14 @@ def analyze_document(
         "density": round(density, 2),
         "advice": deduplicate_advice(list(state.advice)),
     }
+    if emits_categories:
+        category_counts: dict[str, int] = {}
+        for violation in state.violations:
+            category_counts[violation.category] = (
+                category_counts.get(violation.category, 0) + 1
+            )
+        payload["category_counts"] = category_counts
+    return payload
 
 
 def analyze_text(

--- a/src/slop_guard/models.py
+++ b/src/slop_guard/models.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Literal, TypeAlias
+from typing import Literal, NotRequired, TypeAlias
 
 from typing_extensions import TypedDict
 
@@ -11,7 +11,12 @@ BandLabel: TypeAlias = Literal["clean", "light", "moderate", "heavy", "saturated
 
 
 class ViolationPayload(TypedDict):
-    """Structured violation payload returned to CLI and MCP consumers."""
+    """Structured violation payload returned to CLI and MCP consumers.
+
+    The optional ``category`` field appears only when the active pipeline
+    includes rules tagged with a non-default category (i.e. when the
+    writing-quality preset is loaded alongside or instead of the default).
+    """
 
     type: Literal["Violation"]
     rule: str
@@ -20,10 +25,15 @@ class ViolationPayload(TypedDict):
     penalty: int
     start: int
     end: int
+    category: NotRequired[str]
 
 
 class AnalysisPayload(TypedDict):
-    """Structured analyzer result produced by the core analyzer."""
+    """Structured analyzer result produced by the core analyzer.
+
+    The optional ``category_counts`` field appears only when the active
+    pipeline includes rules tagged with a non-default category.
+    """
 
     score: int
     band: BandLabel
@@ -34,6 +44,7 @@ class AnalysisPayload(TypedDict):
     weighted_sum: float
     density: float
     advice: list[str]
+    category_counts: NotRequired[Counts]
 
 
 class SourceAnalysisPayload(AnalysisPayload):
@@ -52,6 +63,7 @@ class Violation:
     penalty: int
     start: int | None = None
     end: int | None = None
+    category: str = "ai_slop"
 
     def explicit_span(self) -> tuple[int, int] | None:
         """Return the exact rule-provided span when one exists."""
@@ -59,9 +71,19 @@ class Violation:
             return None
         return (self.start, self.end)
 
-    def to_payload(self, start: int, end: int) -> ViolationPayload:
-        """Serialize a typed violation for tool output."""
-        return {
+    def to_payload(
+        self, start: int, end: int, *, include_category: bool = False
+    ) -> ViolationPayload:
+        """Serialize a typed violation for tool output.
+
+        Args:
+            start: Resolved start offset in the original text.
+            end: Resolved end offset in the original text.
+            include_category: When True, also emit the rule's category in the
+                payload. Callers should set this only when the active pipeline
+                contains rules from more than the default category.
+        """
+        payload: ViolationPayload = {
             "type": "Violation",
             "rule": self.rule,
             "match": self.match,
@@ -70,6 +92,9 @@ class Violation:
             "start": start,
             "end": end,
         }
+        if include_category:
+            payload["category"] = self.category
+        return payload
 
 
 @dataclass

--- a/src/slop_guard/rules/assets/writing_quality.jsonl
+++ b/src/slop_guard/rules/assets/writing_quality.jsonl
@@ -1,0 +1,14 @@
+{"config": {"context_window_chars": 60, "penalty": -1}, "rule_type": "slop_guard.rules.word.qualifier_word.QualifierWordRule"}
+{"config": {"context_window_chars": 60, "penalty": -2}, "rule_type": "slop_guard.rules.word.pretentious_word.PretentiousWordRule"}
+{"config": {"context_window_chars": 60, "penalty": -1}, "rule_type": "slop_guard.rules.word.ecstatic_adjective.EcstaticAdjectiveRule"}
+{"config": {"context_window_chars": 60, "penalty": -2}, "rule_type": "slop_guard.rules.sentence.verbose_phrase.VerbosePhraseRule"}
+{"config": {"context_window_chars": 60, "penalty": -2}, "rule_type": "slop_guard.rules.sentence.throat_clearing.ThroatClearingRule"}
+{"config": {"context_window_chars": 60, "penalty": -2}, "rule_type": "slop_guard.rules.sentence.over_explanation.OverExplanationRule"}
+{"config": {"context_window_chars": 60, "penalty": -1}, "rule_type": "slop_guard.rules.sentence.redundant_pair.RedundantPairRule"}
+{"config": {"context_window_chars": 60, "penalty": -2}, "rule_type": "slop_guard.rules.sentence.cliche_phrase.ClichePhraseRule"}
+{"config": {"context_window_chars": 60, "penalty": -1}, "rule_type": "slop_guard.rules.sentence.foreign_phrase.ForeignPhraseRule"}
+{"config": {"context_window_chars": 60, "penalty": -2, "tier_two_min_hits": 3}, "rule_type": "slop_guard.rules.sentence.passive_voice.PassiveVoiceRule"}
+{"config": {"max_hits": 5, "min_words": 40, "penalty": -2}, "rule_type": "slop_guard.rules.passage.long_sentence.LongSentenceRule"}
+{"config": {"density_threshold": 1.0, "penalty": -3, "words_basis": 150.0}, "rule_type": "slop_guard.rules.passage.exclamation_density.ExclamationDensityRule"}
+{"config": {"context_window_chars": 60, "penalty": -3}, "rule_type": "slop_guard.rules.passage.emoji_in_prose.EmojiInProseRule"}
+{"config": {"context_window_chars": 60, "penalty": -4}, "rule_type": "slop_guard.rules.paragraph.narrative_heading.NarrativeHeadingRule"}

--- a/src/slop_guard/rules/base.py
+++ b/src/slop_guard/rules/base.py
@@ -48,6 +48,7 @@ class Rule(ABC, Generic[ConfigT]):
     name: str = "rule"
     count_key: str = "rule"
     level: RuleLevel = RuleLevel.PASSAGE
+    category: str = "ai_slop"
 
     def __init__(self, config: ConfigT) -> None:
         """Initialize a rule with explicit configuration."""

--- a/src/slop_guard/rules/catalog.py
+++ b/src/slop_guard/rules/catalog.py
@@ -26,3 +26,22 @@ DEFAULT_RULE_PATHS: tuple[str, ...] = (
     "slop_guard.rules.passage.paragraph_rhythm.ParagraphBalanceRule",
     "slop_guard.rules.passage.paragraph_rhythm.ParagraphCVRule",
 )
+
+WRITING_QUALITY_RULE_PATHS: tuple[str, ...] = (
+    "slop_guard.rules.word.qualifier_word.QualifierWordRule",
+    "slop_guard.rules.word.pretentious_word.PretentiousWordRule",
+    "slop_guard.rules.word.ecstatic_adjective.EcstaticAdjectiveRule",
+    "slop_guard.rules.sentence.verbose_phrase.VerbosePhraseRule",
+    "slop_guard.rules.sentence.throat_clearing.ThroatClearingRule",
+    "slop_guard.rules.sentence.over_explanation.OverExplanationRule",
+    "slop_guard.rules.sentence.redundant_pair.RedundantPairRule",
+    "slop_guard.rules.sentence.cliche_phrase.ClichePhraseRule",
+    "slop_guard.rules.sentence.foreign_phrase.ForeignPhraseRule",
+    "slop_guard.rules.sentence.passive_voice.PassiveVoiceRule",
+    "slop_guard.rules.passage.long_sentence.LongSentenceRule",
+    "slop_guard.rules.passage.exclamation_density.ExclamationDensityRule",
+    "slop_guard.rules.passage.emoji_in_prose.EmojiInProseRule",
+    "slop_guard.rules.paragraph.narrative_heading.NarrativeHeadingRule",
+)
+
+ALL_RULE_PATHS: tuple[str, ...] = DEFAULT_RULE_PATHS + WRITING_QUALITY_RULE_PATHS

--- a/src/slop_guard/rules/paragraph/narrative_heading.py
+++ b/src/slop_guard/rules/paragraph/narrative_heading.py
@@ -1,0 +1,140 @@
+"""Detect narrative-poetic Markdown headings.
+
+Objective: Flag headings of the form "## The {Abstract Noun} of ..." which
+are a strong AI-style structural tell ("The Journey of ...", "The Art of ...",
+"The Power of ..."). These almost always replace a concrete, scannable
+section title.
+
+Example Rule Violations:
+    - "## The Journey of Refactoring"
+    - "## The Art of Caching"
+    - "## The Power of Idempotence"
+
+Example Non-Violations:
+    - "## Caching strategy"
+    - "## How retries work"
+    - "## Refactor plan"
+
+Severity: High per hit; the pattern is rare in authored prose.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_NARRATIVE_NOUN_PATTERN = (
+    "Journey|Art|Power|Beauty|Magic|Essence|Heart|Soul|Spirit|Pursuit|"
+    "Quest|Path|Rise|Dawn|Era|Age|Future|Promise|Wonder"
+)
+_NARRATIVE_HEADING_RE = re.compile(
+    rf"^\s*#{{1,6}}\s+The\s+(?:{_NARRATIVE_NOUN_PATTERN})\s+of\b.*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+@dataclass
+class NarrativeHeadingRuleConfig(RuleConfig):
+    """Config for narrative-poetic Markdown heading detection."""
+
+    penalty: int = field(
+        metadata={
+            "description": ("Penalty applied per matched narrative-poetic heading.")
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each narrative-heading violation."
+            )
+        }
+    )
+
+
+class NarrativeHeadingRule(Rule[NarrativeHeadingRuleConfig]):
+    """Flag headings of the form '## The {abstract noun} of ...'."""
+
+    name = "narrative_heading"
+    count_key = "narrative_heading"
+    level = RuleLevel.PARAGRAPH
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger narrative-heading matches."""
+        return [
+            "## The Journey of Refactoring",
+            "### The Art of Caching",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid narrative-heading matches."""
+        return [
+            "## Caching strategy",
+            "## Refactor plan",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match narrative-poetic Markdown headings and emit one violation each."""
+        violations: list[Violation] = []
+        for match in _NARRATIVE_HEADING_RE.finditer(document.text):
+            heading = match.group(0).strip()
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match="narrative_heading",
+                    context=context_around(
+                        document.text,
+                        match.start(),
+                        match.end(),
+                        width=self.config.context_window_chars,
+                    ),
+                    penalty=self.config.penalty,
+                    start=match.start(),
+                    end=match.end(),
+                )
+            )
+            _ = heading
+
+        if not violations:
+            return RuleResult()
+
+        return RuleResult(
+            violations=violations,
+            advice=[
+                "Replace narrative-poetic headings ('The {Noun} of ...') with concrete, scannable section titles."
+            ],
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> NarrativeHeadingRuleConfig:
+        """Fit penalty from narrative-heading prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        positive_matches = sum(
+            1
+            for sample in positive_samples
+            if _NARRATIVE_HEADING_RE.search(sample) is not None
+        )
+        negative_matches = sum(
+            1
+            for sample in negative_samples
+            if _NARRATIVE_HEADING_RE.search(sample) is not None
+        )
+        return NarrativeHeadingRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/passage/emoji_in_prose.py
+++ b/src/slop_guard/rules/passage/emoji_in_prose.py
@@ -1,0 +1,144 @@
+"""Detect emoji embedded in prose.
+
+Objective: Flag pictograph characters that appear in body text, where they
+typically signal informal AI-generated content rather than authored writing.
+Emoji inside fenced code blocks are ignored.
+
+Example Rule Violations:
+    - "We shipped it 🚀 and the team is thrilled 🎉."
+      Decorative emoji punctuation in plain prose.
+
+Example Non-Violations:
+    - "We shipped it and the team is satisfied with the result."
+      No emoji in prose.
+
+Severity: Medium per hit; emoji in prose nearly always replace a more
+specific written claim.
+"""
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_EMOJI_RE = re.compile(
+    "["
+    "\U0001f300-\U0001f5ff"
+    "\U0001f600-\U0001f64f"
+    "\U0001f680-\U0001f6ff"
+    "\U0001f700-\U0001f77f"
+    "\U0001f780-\U0001f7ff"
+    "\U0001f800-\U0001f8ff"
+    "\U0001f900-\U0001f9ff"
+    "\U0001fa00-\U0001fa6f"
+    "\U0001fa70-\U0001faff"
+    "\U00002600-\U000026ff"
+    "\U00002700-\U000027bf"
+    "]"
+)
+
+
+@dataclass
+class EmojiInProseRuleConfig(RuleConfig):
+    """Config for emoji-in-prose detection."""
+
+    penalty: int = field(
+        metadata={"description": ("Penalty applied per emoji match in non-code prose.")}
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each emoji violation."
+            )
+        }
+    )
+
+
+class EmojiInProseRule(Rule[EmojiInProseRuleConfig]):
+    """Flag emoji characters appearing in body prose."""
+
+    name = "emoji_in_prose"
+    count_key = "emoji_in_prose"
+    level = RuleLevel.PASSAGE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger emoji matches."""
+        return [
+            "We shipped it 🚀 and the team is thrilled 🎉.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid emoji matches."""
+        return [
+            "We shipped it and the team is satisfied with the result.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Find emoji characters outside fenced code and emit one hit each."""
+        masked_text = document.text_with_markdown_code_masked
+        violations: list[Violation] = []
+        per_emoji: Counter[str] = Counter()
+        for match in _EMOJI_RE.finditer(masked_text):
+            char = match.group(0)
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match=char,
+                    context=context_around(
+                        document.text,
+                        match.start(),
+                        match.end(),
+                        width=self.config.context_window_chars,
+                    ),
+                    penalty=self.config.penalty,
+                    start=match.start(),
+                    end=match.end(),
+                )
+            )
+            per_emoji[char] += 1
+
+        if not violations:
+            return RuleResult()
+
+        return RuleResult(
+            violations=violations,
+            advice=[
+                "Remove emoji from prose — replace decorative pictographs with the words they stand in for."
+            ],
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> EmojiInProseRuleConfig:
+        """Fit penalty from emoji prevalence in prose."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_match(sample: str) -> bool:
+            return (
+                _EMOJI_RE.search(
+                    AnalysisDocument.from_text(sample).text_with_markdown_code_masked
+                )
+                is not None
+            )
+
+        positive_matches = sum(1 for sample in positive_samples if has_match(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_match(sample))
+        return EmojiInProseRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/passage/exclamation_density.py
+++ b/src/slop_guard/rules/passage/exclamation_density.py
@@ -1,0 +1,162 @@
+"""Detect excessive exclamation marks across a passage.
+
+Objective: Compute exclamation density relative to passage length and flag
+when the punctuation rate exceeds the configured threshold (mirrors
+``EmDashDensityRule`` and ``ColonDensityRule``).
+
+Example Rule Violations:
+    - "We shipped it! It works! Amazing!"
+      Three exclamations across 7 words.
+
+Example Non-Violations:
+    - "We shipped it. It works. The release closed 12 bugs."
+      Period-only punctuation.
+
+Severity: Medium when over threshold; one violation per passage.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import (
+    fit_penalty_contrastive,
+    fit_threshold_high_contrastive,
+)
+
+_EXCLAMATION_RE = re.compile(r"!")
+
+
+@dataclass
+class ExclamationDensityRuleConfig(RuleConfig):
+    """Config for exclamation-density thresholding."""
+
+    words_basis: float = field(
+        metadata={
+            "description": (
+                "Word count used as the denominator basis for computing "
+                "exclamation density (typically 150)."
+            )
+        }
+    )
+    density_threshold: float = field(
+        metadata={
+            "description": (
+                "Maximum allowed exclamations per words_basis words; a "
+                "density strictly greater than this triggers the violation."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied once when exclamation density exceeds "
+                "density_threshold."
+            )
+        }
+    )
+
+
+class ExclamationDensityRule(Rule[ExclamationDensityRuleConfig]):
+    """Detect high exclamation density relative to passage length."""
+
+    name = "exclamation_density"
+    count_key = "exclamation_density"
+    level = RuleLevel.PASSAGE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger exclamation-density matches."""
+        return [
+            "We shipped it! It works! Amazing!",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid exclamation-density matches."""
+        return [
+            "We shipped it. It works. The release closed 12 bugs.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Compute exclamation-per-basis ratio and emit one density violation."""
+        word_count = document.word_count_without_code_blocks
+        if word_count <= 0:
+            return RuleResult()
+
+        exclamation_count = len(
+            _EXCLAMATION_RE.findall(document.text_without_code_blocks)
+        )
+        ratio_per_basis = (exclamation_count / word_count) * self.config.words_basis
+        if ratio_per_basis <= self.config.density_threshold:
+            return RuleResult()
+
+        return RuleResult(
+            violations=[
+                Violation(
+                    rule=self.name,
+                    match="exclamation_density",
+                    context=(
+                        f"{exclamation_count} exclamations in {word_count} words "
+                        f"({ratio_per_basis:.1f} per {int(self.config.words_basis)} words)"
+                    ),
+                    penalty=self.config.penalty,
+                )
+            ],
+            advice=[
+                f"Too many exclamation marks ({exclamation_count} in {word_count} words) — "
+                "let the content carry the emphasis."
+            ],
+            count_deltas={self.count_key: 1},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> ExclamationDensityRuleConfig:
+        """Fit exclamation density threshold from empirical ratios."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def ratio(sample: str) -> float | None:
+            doc = AnalysisDocument.from_text(sample)
+            wc = doc.word_count_without_code_blocks
+            if wc <= 0:
+                return None
+            count = len(_EXCLAMATION_RE.findall(doc.text_without_code_blocks))
+            return (count / wc) * self.config.words_basis
+
+        positive_ratios = [
+            r for sample in positive_samples if (r := ratio(sample)) is not None
+        ]
+        if not positive_ratios:
+            return self.config
+        negative_ratios = [
+            r for sample in negative_samples if (r := ratio(sample)) is not None
+        ]
+
+        density_threshold = fit_threshold_high_contrastive(
+            default_value=self.config.density_threshold,
+            positive_values=positive_ratios,
+            negative_values=negative_ratios,
+            lower=0.0,
+            upper=100.0,
+            positive_quantile=0.90,
+            negative_quantile=0.10,
+            blend_pivot=5.0,
+        )
+        positive_matches = sum(1 for r in positive_ratios if r > density_threshold)
+        negative_matches = sum(1 for r in negative_ratios if r > density_threshold)
+
+        return ExclamationDensityRuleConfig(
+            words_basis=self.config.words_basis,
+            density_threshold=density_threshold,
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_ratios),
+                negative_matches=negative_matches,
+                negative_total=len(negative_ratios),
+            ),
+        )

--- a/src/slop_guard/rules/passage/long_sentence.py
+++ b/src/slop_guard/rules/passage/long_sentence.py
@@ -1,0 +1,142 @@
+"""Detect moderately long sentences with a per-document cap.
+
+Objective: Flag any single sentence exceeding a word-count threshold, capping
+how many such hits a single document can contribute. This is a lighter-touch
+companion to ``ExtremeSentenceRule`` (which targets only true run-ons at a
+much higher threshold).
+
+Example Rule Violations:
+    - A single sentence of 45 words chaining several clauses with commas and
+      conjunctions instead of breaking into shorter statements.
+
+Example Non-Violations:
+    - "The update shipped on Tuesday."
+      Short, direct sentence.
+    - A passage where every sentence stays under the configured threshold.
+
+Severity: Medium per hit, capped at ``max_hits`` so one bad section can't
+saturate the score on its own.
+"""
+
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+
+@dataclass
+class LongSentenceRuleConfig(RuleConfig):
+    """Config for long-sentence detection with a per-document cap."""
+
+    min_words: int = field(
+        metadata={
+            "description": (
+                "Minimum sentence length (in words) that qualifies as long; "
+                "any sentence with at least this many words emits a violation."
+            )
+        }
+    )
+    max_hits: int = field(
+        metadata={
+            "description": (
+                "Maximum number of long-sentence violations recorded per "
+                "document. Additional matches beyond this cap are ignored."
+            )
+        }
+    )
+    penalty: int = field(
+        metadata={
+            "description": ("Penalty applied per long-sentence hit, up to max_hits.")
+        }
+    )
+
+
+class LongSentenceRule(Rule[LongSentenceRuleConfig]):
+    """Flag sentences exceeding ``min_words``, capped at ``max_hits``."""
+
+    name = "long_sentence"
+    count_key = "long_sentence"
+    level = RuleLevel.PASSAGE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger long-sentence matches."""
+        return [
+            " ".join(["word"] * (self.config.min_words + 5)),
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid long-sentence matches."""
+        return [
+            "Short sentences keep ideas separate. Each one carries one claim.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Walk sentences and emit a violation per qualifying hit, up to cap."""
+        violations: list[Violation] = []
+        advice: list[str] = []
+
+        for idx, (sentence, word_count) in enumerate(
+            zip(
+                document.sentence_analysis_sentences,
+                document.sentence_analysis_word_counts,
+            )
+        ):
+            if word_count < self.config.min_words:
+                continue
+            if len(violations) >= self.config.max_hits:
+                break
+            preview = f'"{sentence[:80]}..."' if len(sentence) > 80 else f'"{sentence}"'
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match="long_sentence",
+                    context=(
+                        f"Sentence {idx + 1} has {word_count} words "
+                        f"(>= {self.config.min_words}): {preview}"
+                    ),
+                    penalty=self.config.penalty,
+                )
+            )
+            advice.append(
+                f"Sentence {idx + 1} is {word_count} words — break it into shorter sentences."
+            )
+
+        if not violations:
+            return RuleResult()
+
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> LongSentenceRuleConfig:
+        """Fit penalty from long-sentence prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_long(sample: str) -> bool:
+            doc = AnalysisDocument.from_text(sample)
+            return any(
+                wc >= self.config.min_words for wc in doc.sentence_analysis_word_counts
+            )
+
+        positive_matches = sum(1 for sample in positive_samples if has_long(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_long(sample))
+        return LongSentenceRuleConfig(
+            min_words=self.config.min_words,
+            max_hits=self.config.max_hits,
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+        )

--- a/src/slop_guard/rules/pipeline.py
+++ b/src/slop_guard/rules/pipeline.py
@@ -3,14 +3,14 @@
 import json
 import math
 from collections.abc import Iterable, Mapping
-from dataclasses import fields, is_dataclass
+from dataclasses import fields, is_dataclass, replace
 from importlib.resources import files
 from pathlib import Path
 from typing import Any, TypeAlias
 
 from slop_guard.config import DEFAULT_HYPERPARAMETERS
 from slop_guard.document import AnalysisDocument
-from slop_guard.models import AnalysisState
+from slop_guard.models import AnalysisState, RuleResult
 from slop_guard.scoring import compute_weighted_sum
 
 from .base import Label, Rule, RuleConfig
@@ -33,6 +33,22 @@ class Pipeline:
     def count_keys(self) -> tuple[str, ...]:
         """Return the ordered count keys used by this pipeline."""
         return tuple(dict.fromkeys(rule.count_key for rule in self.rules))
+
+    @property
+    def categories(self) -> tuple[str, ...]:
+        """Return the unique rule categories present in this pipeline."""
+        return tuple(dict.fromkeys(rule.category for rule in self.rules))
+
+    @property
+    def emits_categories(self) -> bool:
+        """Return whether the pipeline carries any non-default category.
+
+        Default-only pipelines (every rule tagged ``ai_slop``) suppress the
+        ``category`` field on violations and ``category_counts`` on results
+        so the JSON shape matches the pre-category release. Pipelines that
+        include any other category opt every consumer into the new fields.
+        """
+        return any(rule.category != "ai_slop" for rule in self.rules)
 
     @classmethod
     def from_jsonl(cls, path: str | Path | None = None) -> "Pipeline":
@@ -64,7 +80,18 @@ class Pipeline:
         """Apply all rules in order and merge their outputs."""
         state = AnalysisState.initial(self.count_keys)
         for rule in self.rules:
-            state = state.merge(rule.forward(document))
+            result = rule.forward(document)
+            if result.violations:
+                tagged = [
+                    replace(violation, category=rule.category)
+                    for violation in result.violations
+                ]
+                result = RuleResult(
+                    violations=tagged,
+                    advice=result.advice,
+                    count_deltas=result.count_deltas,
+                )
+            state = state.merge(result)
         return state
 
     def fit(

--- a/src/slop_guard/rules/registry.py
+++ b/src/slop_guard/rules/registry.py
@@ -4,7 +4,7 @@ from importlib import import_module
 from typing import Any, TypeAlias
 
 from .base import Rule
-from .catalog import DEFAULT_RULE_PATHS
+from .catalog import ALL_RULE_PATHS, DEFAULT_RULE_PATHS
 
 RuleType: TypeAlias = type[Rule[Any]]
 RuleList: TypeAlias = list[Rule[Any]]
@@ -37,7 +37,7 @@ def _register_rule_type(rule_type: RuleType) -> RuleType:
     return rule_type
 
 
-for _rule_path in DEFAULT_RULE_PATHS:
+for _rule_path in ALL_RULE_PATHS:
     _RULE_PATHS_BY_KEY[_rule_path] = _rule_path
     _RULE_PATHS_BY_KEY[_rule_path.rpartition(".")[2]] = _rule_path
 

--- a/src/slop_guard/rules/sentence/cliche_phrase.py
+++ b/src/slop_guard/rules/sentence/cliche_phrase.py
@@ -1,0 +1,159 @@
+"""Detect worn metaphorical clichés.
+
+Objective: Flag idioms whose figurative force has been worn out (Orwell:
+never use a metaphor you're accustomed to seeing in print).
+
+Example Rule Violations:
+    - "Let's think outside the box and move the needle."
+      Stacks two corporate clichés in one breath.
+    - "The cache hit rate is just the tip of the iceberg."
+      Reaches for a cliché instead of naming the underlying issue.
+
+Example Non-Violations:
+    - "We can reduce p99 by batching writes; cache misses dominate the rest."
+      Concrete causes named directly.
+    - "The lock contention pattern repeats across three subsystems."
+      Specific observation without metaphor.
+
+Severity: Medium per hit; clichés rarely add information their replacement
+sentence cannot.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_CLICHE_PHRASES: tuple[str, ...] = (
+    "think outside the box",
+    "low-hanging fruit",
+    "move the needle",
+    "tip of the iceberg",
+    "elephant in the room",
+    "perfect storm",
+    "silver bullet",
+    "double-edged sword",
+    "hit the ground running",
+    "reinvent the wheel",
+    "boil the ocean",
+    "circle back",
+    "drink the kool-aid",
+    "raise the bar",
+    "push the envelope",
+    "best of breed",
+    "win-win",
+    "synergy",
+    "core competency",
+    "paradigm shift",
+)
+_CLICHE_RE_LIST: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(re.escape(phrase), re.IGNORECASE) for phrase in _CLICHE_PHRASES
+)
+
+
+@dataclass
+class ClichePhraseRuleConfig(RuleConfig):
+    """Config for cliché-phrase matching."""
+
+    penalty: int = field(
+        metadata={"description": ("Penalty applied per matched cliché phrase.")}
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each cliché violation."
+            )
+        }
+    )
+
+
+class ClichePhraseRule(Rule[ClichePhraseRuleConfig]):
+    """Flag worn metaphors whose figurative force has eroded."""
+
+    name = "cliche_phrase"
+    count_key = "cliche_phrases"
+    level = RuleLevel.SENTENCE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger cliché matches."""
+        return [
+            "Let's think outside the box and move the needle.",
+            "The cache hit rate is just the tip of the iceberg.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid cliché matches."""
+        return [
+            "We can reduce p99 by batching writes.",
+            "Lock contention repeats across three subsystems.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each cliché and emit one violation per hit."""
+        violations: list[Violation] = []
+        seen: set[str] = set()
+        advice_order: list[str] = []
+        for pattern in _CLICHE_RE_LIST:
+            for match in pattern.finditer(document.text):
+                phrase = match.group(0).lower()
+                violations.append(
+                    Violation(
+                        rule=self.name,
+                        match=phrase,
+                        context=context_around(
+                            document.text,
+                            match.start(),
+                            match.end(),
+                            width=self.config.context_window_chars,
+                        ),
+                        penalty=self.config.penalty,
+                        start=match.start(),
+                        end=match.end(),
+                    )
+                )
+                if phrase not in seen:
+                    advice_order.append(phrase)
+                    seen.add(phrase)
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Cut '{phrase}' — name the concrete idea the cliché stands in for."
+            for phrase in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> ClichePhraseRuleConfig:
+        """Fit penalty from cliché prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_match(sample: str) -> bool:
+            lower_text = sample.lower()
+            return any(phrase in lower_text for phrase in _CLICHE_PHRASES)
+
+        positive_matches = sum(1 for sample in positive_samples if has_match(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_match(sample))
+        return ClichePhraseRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/sentence/foreign_phrase.py
+++ b/src/slop_guard/rules/sentence/foreign_phrase.py
@@ -1,0 +1,159 @@
+"""Detect foreign and Latin phrases with plain-English equivalents.
+
+Objective: Flag Latin/French borrowings where a plain English phrase is at
+least as clear (Orwell's rule 5: never use a foreign phrase, scientific word,
+or jargon word if you can think of an everyday English equivalent).
+
+Example Rule Violations:
+    - "Per se, the migration was successful."
+      Uses "per se" where "by itself" reads more directly.
+    - "We need an ad hoc fix vis-a-vis the regression."
+      Stacks two unnecessary borrowings.
+
+Example Non-Violations:
+    - "By itself, the migration was successful."
+      Plain English equivalent.
+    - "We need an improvised fix for the regression."
+      Direct phrasing.
+
+Severity: Low per hit; the penalty is light because some technical writing
+legitimately uses these terms.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_FOREIGN_REPLACEMENTS: tuple[tuple[str, str], ...] = (
+    ("per se", "by itself"),
+    ("vis-a-vis", "compared to"),
+    ("vis-à-vis", "compared to"),
+    ("ad hoc", "improvised"),
+    ("de facto", "in practice"),
+    ("status quo", "current state"),
+    ("ipso facto", "by that fact"),
+    ("inter alia", "among others"),
+    ("ergo", "so"),
+    ("a priori", "from first principles"),
+)
+_FOREIGN_BY_PHRASE: dict[str, str] = {
+    phrase.lower(): replacement for phrase, replacement in _FOREIGN_REPLACEMENTS
+}
+_FOREIGN_RE_LIST: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(r"\b" + re.escape(phrase) + r"\b", re.IGNORECASE)
+    for phrase, _ in _FOREIGN_REPLACEMENTS
+)
+
+
+@dataclass
+class ForeignPhraseRuleConfig(RuleConfig):
+    """Config for foreign/Latin phrase matching with replacements."""
+
+    penalty: int = field(
+        metadata={
+            "description": ("Penalty applied per matched foreign or Latin phrase.")
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each foreign-phrase violation."
+            )
+        }
+    )
+
+
+class ForeignPhraseRule(Rule[ForeignPhraseRuleConfig]):
+    """Flag Latin/French borrowings and recommend the plain-English form."""
+
+    name = "foreign_phrase"
+    count_key = "foreign_phrases"
+    level = RuleLevel.SENTENCE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger foreign-phrase matches."""
+        return [
+            "Per se, the migration was successful.",
+            "We need an ad hoc fix.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid foreign-phrase matches."""
+        return [
+            "By itself, the migration was successful.",
+            "We need an improvised fix.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each foreign phrase and emit a replacement-aware violation."""
+        violations: list[Violation] = []
+        seen: set[str] = set()
+        advice_order: list[str] = []
+        for pattern in _FOREIGN_RE_LIST:
+            for match in pattern.finditer(document.text):
+                phrase = match.group(0).lower()
+                replacement = _FOREIGN_BY_PHRASE.get(phrase)
+                if replacement is None:
+                    continue
+                violations.append(
+                    Violation(
+                        rule=self.name,
+                        match=phrase,
+                        context=context_around(
+                            document.text,
+                            match.start(),
+                            match.end(),
+                            width=self.config.context_window_chars,
+                        ),
+                        penalty=self.config.penalty,
+                        start=match.start(),
+                        end=match.end(),
+                    )
+                )
+                if phrase not in seen:
+                    advice_order.append(phrase)
+                    seen.add(phrase)
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Replace '{phrase}' with '{_FOREIGN_BY_PHRASE[phrase]}'."
+            for phrase in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> ForeignPhraseRuleConfig:
+        """Fit penalty from foreign-phrase prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_match(sample: str) -> bool:
+            lower_text = sample.lower()
+            return any(phrase in lower_text for phrase in _FOREIGN_BY_PHRASE)
+
+        positive_matches = sum(1 for sample in positive_samples if has_match(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_match(sample))
+        return ForeignPhraseRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/sentence/over_explanation.py
+++ b/src/slop_guard/rules/sentence/over_explanation.py
@@ -1,0 +1,146 @@
+"""Detect over-explanation phrases that announce the obvious.
+
+Objective: Flag prefaces that label what follows as self-evident. If it is
+obvious you don't need to say so; if it isn't, saying "obviously" won't fix it.
+
+Example Rule Violations:
+    - "Needless to say, retries should be idempotent."
+      Announces obviousness instead of just stating the rule.
+    - "It is obvious that the cache hit rate matters."
+      Same pattern, longer.
+
+Example Non-Violations:
+    - "Retries should be idempotent."
+      Direct statement.
+    - "Cache hit rate dropped from 92% to 41%."
+      Concrete claim with a number.
+
+Severity: Medium per hit; almost always replaceable with the bare claim.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_OVER_EXPLANATION_PHRASES: tuple[str, ...] = (
+    "needless to say",
+    "as everyone knows",
+    "it is obvious that",
+    "it goes without saying",
+    "as you can see",
+    "as we all know",
+)
+_OVER_EXPLANATION_RE_LIST: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(re.escape(phrase), re.IGNORECASE) for phrase in _OVER_EXPLANATION_PHRASES
+)
+
+
+@dataclass
+class OverExplanationRuleConfig(RuleConfig):
+    """Config for over-explanation phrase matching."""
+
+    penalty: int = field(
+        metadata={
+            "description": ("Penalty applied per matched over-explanation phrase.")
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each over-explanation violation."
+            )
+        }
+    )
+
+
+class OverExplanationRule(Rule[OverExplanationRuleConfig]):
+    """Flag prefaces that announce what follows is self-evident."""
+
+    name = "over_explanation"
+    count_key = "over_explanation"
+    level = RuleLevel.SENTENCE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger over-explanation matches."""
+        return [
+            "Needless to say, retries should be idempotent.",
+            "It is obvious that the cache hit rate matters.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid over-explanation matches."""
+        return [
+            "Retries should be idempotent.",
+            "Cache hit rate dropped from 92% to 41%.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each over-explanation phrase and emit one violation per hit."""
+        violations: list[Violation] = []
+        seen: set[str] = set()
+        advice_order: list[str] = []
+        for pattern in _OVER_EXPLANATION_RE_LIST:
+            for match in pattern.finditer(document.text):
+                phrase = match.group(0).lower()
+                violations.append(
+                    Violation(
+                        rule=self.name,
+                        match=phrase,
+                        context=context_around(
+                            document.text,
+                            match.start(),
+                            match.end(),
+                            width=self.config.context_window_chars,
+                        ),
+                        penalty=self.config.penalty,
+                        start=match.start(),
+                        end=match.end(),
+                    )
+                )
+                if phrase not in seen:
+                    advice_order.append(phrase)
+                    seen.add(phrase)
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Cut '{phrase}' — state the claim without prefacing it as obvious."
+            for phrase in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> OverExplanationRuleConfig:
+        """Fit penalty from over-explanation prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_match(sample: str) -> bool:
+            lower_text = sample.lower()
+            return any(phrase in lower_text for phrase in _OVER_EXPLANATION_PHRASES)
+
+        positive_matches = sum(1 for sample in positive_samples if has_match(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_match(sample))
+        return OverExplanationRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/sentence/passive_voice.py
+++ b/src/slop_guard/rules/sentence/passive_voice.py
@@ -1,0 +1,228 @@
+"""Detect passive voice constructions with a two-tier confidence model.
+
+Objective: Flag passive voice while keeping false positives low. Tier 1
+matches the unambiguous "was/were/is/are X by" agent pattern. Tier 2 counts
+"be-verb + curated participle" matches and only flags when the document
+contains at least ``tier_two_min_hits`` instances (density evidence rather
+than a single accidental hit).
+
+Example Rule Violations:
+    - "The migration was approved by the architecture council."
+      Tier 1: explicit agent makes the passive construction certain.
+    - "The cache is invalidated. Logs are dropped. Errors are swallowed."
+      Tier 2: three be-verb + participle pairs trip the density gate.
+
+Example Non-Violations:
+    - "The architecture council approved the migration."
+      Active rewrite of the same claim.
+    - "She was born in 1962." / "The pattern is known for X."
+      Common false-positive idioms; participles deliberately excluded from
+      the tier-2 list.
+
+Severity: Medium per hit; passive voice often hides who did what.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_BE_VERBS = "was|were|is|are|been|being|am|be"
+
+_TIER_ONE_RE = re.compile(
+    rf"\b(?:{_BE_VERBS})\s+\w+(?:ed|en)\s+by\b",
+    re.IGNORECASE,
+)
+
+_TIER_TWO_PARTICIPLES: tuple[str, ...] = (
+    "approved",
+    "rejected",
+    "completed",
+    "delivered",
+    "executed",
+    "deployed",
+    "released",
+    "shipped",
+    "implemented",
+    "designed",
+    "developed",
+    "tested",
+    "verified",
+    "validated",
+    "reviewed",
+    "audited",
+    "measured",
+    "observed",
+    "recorded",
+    "tracked",
+    "monitored",
+    "discussed",
+    "considered",
+    "examined",
+    "investigated",
+    "analyzed",
+    "evaluated",
+    "addressed",
+    "resolved",
+    "fixed",
+    "patched",
+    "deprecated",
+    "removed",
+    "replaced",
+    "updated",
+    "migrated",
+    "configured",
+    "scheduled",
+    "triggered",
+    "invoked",
+    "invalidated",
+    "dropped",
+    "swallowed",
+    "consumed",
+    "produced",
+    "generated",
+    "computed",
+    "rendered",
+    "transmitted",
+    "decoded",
+    "encoded",
+    "captured",
+)
+_TIER_TWO_RE = re.compile(
+    rf"\b(?:{_BE_VERBS})\s+(?:" + "|".join(_TIER_TWO_PARTICIPLES) + r")\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class PassiveVoiceRuleConfig(RuleConfig):
+    """Config for two-tier passive-voice detection."""
+
+    penalty: int = field(
+        metadata={
+            "description": (
+                "Penalty applied per tier-1 hit and per tier-2 hit when the "
+                "tier-2 minimum-hits gate fires."
+            )
+        }
+    )
+    tier_two_min_hits: int = field(
+        metadata={
+            "description": (
+                "Minimum number of tier-2 (be-verb + curated participle) "
+                "matches required before any tier-2 violations are emitted."
+            )
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each passive-voice violation."
+            )
+        }
+    )
+
+
+class PassiveVoiceRule(Rule[PassiveVoiceRuleConfig]):
+    """Flag passive voice with high-confidence and density-gated tiers."""
+
+    name = "passive_voice"
+    count_key = "passive_voice"
+    level = RuleLevel.SENTENCE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger passive-voice matches."""
+        return [
+            "The migration was approved by the architecture council.",
+            "The cache is invalidated. Logs are dropped. Errors are swallowed.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid passive-voice matches."""
+        return [
+            "The architecture council approved the migration.",
+            "She was born in 1962.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Apply tier-1 per-hit detection and gated tier-2 density detection."""
+        text = document.text
+        violations: list[Violation] = []
+
+        for match in _TIER_ONE_RE.finditer(text):
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match=match.group(0).lower(),
+                    context=context_around(
+                        text,
+                        match.start(),
+                        match.end(),
+                        width=self.config.context_window_chars,
+                    ),
+                    penalty=self.config.penalty,
+                    start=match.start(),
+                    end=match.end(),
+                )
+            )
+
+        tier_two_matches = list(_TIER_TWO_RE.finditer(text))
+        if len(tier_two_matches) >= self.config.tier_two_min_hits:
+            for match in tier_two_matches:
+                violations.append(
+                    Violation(
+                        rule=self.name,
+                        match=match.group(0).lower(),
+                        context=context_around(
+                            text,
+                            match.start(),
+                            match.end(),
+                            width=self.config.context_window_chars,
+                        ),
+                        penalty=self.config.penalty,
+                        start=match.start(),
+                        end=match.end(),
+                    )
+                )
+
+        if not violations:
+            return RuleResult()
+
+        advice = ["Rewrite passive clauses in active voice — name who acted on what."]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> PassiveVoiceRuleConfig:
+        """Fit penalty from passive-voice prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_match(sample: str) -> bool:
+            if _TIER_ONE_RE.search(sample) is not None:
+                return True
+            return len(_TIER_TWO_RE.findall(sample)) >= self.config.tier_two_min_hits
+
+        positive_matches = sum(1 for sample in positive_samples if has_match(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_match(sample))
+        return PassiveVoiceRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            tier_two_min_hits=self.config.tier_two_min_hits,
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/sentence/redundant_pair.py
+++ b/src/slop_guard/rules/sentence/redundant_pair.py
@@ -1,0 +1,162 @@
+"""Detect redundant word pairs where one word implies the other.
+
+Objective: Flag stock phrases like "completely destroyed" or "end result"
+where the modifier is already implicit in the other word.
+
+Example Rule Violations:
+    - "The cache was completely destroyed."
+      "Destroyed" already implies completeness.
+    - "We need to revert back to the previous schema."
+      "Revert" already implies "back".
+
+Example Non-Violations:
+    - "The cache was destroyed."
+      Single, sufficient verb.
+    - "We need to revert to the previous schema."
+      Concise form.
+
+Severity: Low per hit; the redundant word is always a free deletion.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_REDUNDANT_PAIRS: tuple[str, ...] = (
+    "completely destroyed",
+    "totally unique",
+    "absolutely essential",
+    "end result",
+    "final outcome",
+    "past history",
+    "future plans",
+    "close proximity",
+    "free gift",
+    "advance warning",
+    "advance planning",
+    "true fact",
+    "actual fact",
+    "general consensus",
+    "personal opinion",
+    "revert back",
+    "repeat again",
+    "added bonus",
+    "unexpected surprise",
+    "exact same",
+    "join together",
+    "merge together",
+    "combine together",
+)
+_REDUNDANT_PAIR_RE_LIST: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(r"\b" + re.escape(phrase) + r"\b", re.IGNORECASE)
+    for phrase in _REDUNDANT_PAIRS
+)
+
+
+@dataclass
+class RedundantPairRuleConfig(RuleConfig):
+    """Config for redundant-pair phrase matching."""
+
+    penalty: int = field(
+        metadata={"description": ("Penalty applied per matched redundant phrase pair.")}
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each redundant-pair violation."
+            )
+        }
+    )
+
+
+class RedundantPairRule(Rule[RedundantPairRuleConfig]):
+    """Flag pairs where one word is implied by the other."""
+
+    name = "redundant_pair"
+    count_key = "redundant_pairs"
+    level = RuleLevel.SENTENCE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger redundant-pair matches."""
+        return [
+            "The cache was completely destroyed.",
+            "We need to revert back to the previous schema.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid redundant-pair matches."""
+        return [
+            "The cache was destroyed.",
+            "We need to revert to the previous schema.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each redundant pair and emit one violation per hit."""
+        violations: list[Violation] = []
+        seen: set[str] = set()
+        advice_order: list[str] = []
+        for pattern in _REDUNDANT_PAIR_RE_LIST:
+            for match in pattern.finditer(document.text):
+                phrase = match.group(0).lower()
+                violations.append(
+                    Violation(
+                        rule=self.name,
+                        match=phrase,
+                        context=context_around(
+                            document.text,
+                            match.start(),
+                            match.end(),
+                            width=self.config.context_window_chars,
+                        ),
+                        penalty=self.config.penalty,
+                        start=match.start(),
+                        end=match.end(),
+                    )
+                )
+                if phrase not in seen:
+                    advice_order.append(phrase)
+                    seen.add(phrase)
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Cut '{phrase}' — keep one word; the other is implied."
+            for phrase in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> RedundantPairRuleConfig:
+        """Fit penalty from redundant-pair prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_match(sample: str) -> bool:
+            lower_text = sample.lower()
+            return any(phrase in lower_text for phrase in _REDUNDANT_PAIRS)
+
+        positive_matches = sum(1 for sample in positive_samples if has_match(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_match(sample))
+        return RedundantPairRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/sentence/throat_clearing.py
+++ b/src/slop_guard/rules/sentence/throat_clearing.py
@@ -1,0 +1,148 @@
+"""Detect throat-clearing phrases that delay the actual point.
+
+Objective: Flag meta-framing constructions that announce something is about
+to be said instead of just saying it (Zinsser: don't waste the first sentence
+clearing your throat).
+
+Example Rule Violations:
+    - "It should be pointed out that the index is unused."
+      Frames the claim instead of stating it.
+    - "Truth be told, the migration regressed throughput."
+      Performative honesty preface delays the actual finding.
+
+Example Non-Violations:
+    - "The index is unused."
+      States the claim directly.
+    - "The migration regressed throughput by 12%."
+      Direct finding with a number.
+
+Severity: Medium per hit; the framing always wastes attention.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_THROAT_CLEARING_PHRASES: tuple[str, ...] = (
+    "it should be pointed out that",
+    "the fact of the matter is",
+    "truth be told",
+    "it goes without saying that",
+    "it is interesting to note that",
+    "one might argue that",
+    "as a matter of fact",
+    "when all is said and done",
+)
+_THROAT_CLEARING_RE_LIST: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(re.escape(phrase), re.IGNORECASE) for phrase in _THROAT_CLEARING_PHRASES
+)
+
+
+@dataclass
+class ThroatClearingRuleConfig(RuleConfig):
+    """Config for throat-clearing phrase matching."""
+
+    penalty: int = field(
+        metadata={
+            "description": ("Penalty applied per matched throat-clearing phrase.")
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each throat-clearing violation."
+            )
+        }
+    )
+
+
+class ThroatClearingRule(Rule[ThroatClearingRuleConfig]):
+    """Flag meta-framing phrases that delay the actual point."""
+
+    name = "throat_clearing"
+    count_key = "throat_clearing"
+    level = RuleLevel.SENTENCE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger throat-clearing matches."""
+        return [
+            "It should be pointed out that the index is unused.",
+            "Truth be told, the migration regressed throughput.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid throat-clearing matches."""
+        return [
+            "The index is unused.",
+            "The migration regressed throughput by 12%.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each throat-clearing phrase and emit one violation per hit."""
+        violations: list[Violation] = []
+        seen: set[str] = set()
+        advice_order: list[str] = []
+        for pattern in _THROAT_CLEARING_RE_LIST:
+            for match in pattern.finditer(document.text):
+                phrase = match.group(0).lower()
+                violations.append(
+                    Violation(
+                        rule=self.name,
+                        match=phrase,
+                        context=context_around(
+                            document.text,
+                            match.start(),
+                            match.end(),
+                            width=self.config.context_window_chars,
+                        ),
+                        penalty=self.config.penalty,
+                        start=match.start(),
+                        end=match.end(),
+                    )
+                )
+                if phrase not in seen:
+                    advice_order.append(phrase)
+                    seen.add(phrase)
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Cut '{phrase}' — state the claim directly." for phrase in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> ThroatClearingRuleConfig:
+        """Fit penalty from throat-clearing prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_match(sample: str) -> bool:
+            lower_text = sample.lower()
+            return any(phrase in lower_text for phrase in _THROAT_CLEARING_PHRASES)
+
+        positive_matches = sum(1 for sample in positive_samples if has_match(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_match(sample))
+        return ThroatClearingRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/sentence/verbose_phrase.py
+++ b/src/slop_guard/rules/sentence/verbose_phrase.py
@@ -1,0 +1,162 @@
+"""Detect wordy phrases with shorter equivalents.
+
+Objective: Flag verbose constructions and recommend the concise replacement
+(Strunk & White: omit needless words). Each entry pairs the wordy phrase with
+its plain-English substitute.
+
+Example Rule Violations:
+    - "We migrated in order to reduce cost."
+      Uses "in order to" where "to" suffices.
+    - "Due to the fact that the disk was full, writes failed."
+      Uses "due to the fact that" where "because" suffices.
+
+Example Non-Violations:
+    - "We migrated to reduce cost."
+      Uses the concise form already.
+    - "Writes failed because the disk was full."
+      Uses "because" directly.
+
+Severity: Medium per hit; replacements are deterministic and unambiguous.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_VERBOSE_REPLACEMENTS: tuple[tuple[str, str], ...] = (
+    ("in order to", "to"),
+    ("due to the fact that", "because"),
+    ("at the present time", "now"),
+    ("at this point in time", "now"),
+    ("has the ability to", "can"),
+    ("have the ability to", "can"),
+    ("the vast majority of", "most"),
+    ("a large number of", "many"),
+    ("a small number of", "a few"),
+    ("whether or not", "whether"),
+    ("for the purpose of", "for"),
+    ("with regard to", "about"),
+    ("with respect to", "about"),
+    ("in the event that", "if"),
+    ("in spite of the fact that", "although"),
+    ("on a regular basis", "regularly"),
+    ("in close proximity to", "near"),
+    ("at a later date", "later"),
+    ("prior to", "before"),
+    ("subsequent to", "after"),
+)
+_VERBOSE_BY_PHRASE: dict[str, str] = {
+    phrase.lower(): replacement for phrase, replacement in _VERBOSE_REPLACEMENTS
+}
+_VERBOSE_RE_LIST: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(re.escape(phrase), re.IGNORECASE) for phrase, _ in _VERBOSE_REPLACEMENTS
+)
+
+
+@dataclass
+class VerbosePhraseRuleConfig(RuleConfig):
+    """Config for verbose-phrase matching with replacements."""
+
+    penalty: int = field(
+        metadata={"description": ("Penalty applied per matched verbose phrase.")}
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each verbose-phrase violation."
+            )
+        }
+    )
+
+
+class VerbosePhraseRule(Rule[VerbosePhraseRuleConfig]):
+    """Flag verbose phrases and recommend the concise replacement."""
+
+    name = "verbose_phrase"
+    count_key = "verbose_phrases"
+    level = RuleLevel.SENTENCE
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger verbose-phrase matches."""
+        return [
+            "We migrated in order to reduce cost.",
+            "Due to the fact that the disk was full, writes failed.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid verbose-phrase matches."""
+        return [
+            "We migrated to reduce cost.",
+            "Writes failed because the disk was full.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each verbose phrase and emit a replacement-aware violation."""
+        violations: list[Violation] = []
+        seen_phrases: set[str] = set()
+        advice_order: list[str] = []
+        for pattern in _VERBOSE_RE_LIST:
+            for match in pattern.finditer(document.text):
+                phrase = match.group(0).lower()
+                violations.append(
+                    Violation(
+                        rule=self.name,
+                        match=phrase,
+                        context=context_around(
+                            document.text,
+                            match.start(),
+                            match.end(),
+                            width=self.config.context_window_chars,
+                        ),
+                        penalty=self.config.penalty,
+                        start=match.start(),
+                        end=match.end(),
+                    )
+                )
+                if phrase not in seen_phrases:
+                    advice_order.append(phrase)
+                    seen_phrases.add(phrase)
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Replace '{phrase}' with '{_VERBOSE_BY_PHRASE[phrase]}'."
+            for phrase in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> VerbosePhraseRuleConfig:
+        """Fit penalty from verbose-phrase prevalence in the fit corpus."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        def has_match(sample: str) -> bool:
+            lower_text = sample.lower()
+            return any(phrase in lower_text for phrase in _VERBOSE_BY_PHRASE)
+
+        positive_matches = sum(1 for sample in positive_samples if has_match(sample))
+        negative_matches = sum(1 for sample in negative_samples if has_match(sample))
+        return VerbosePhraseRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/word/ecstatic_adjective.py
+++ b/src/slop_guard/rules/word/ecstatic_adjective.py
@@ -1,0 +1,160 @@
+"""Detect vague high-praise adjectives.
+
+Objective: Flag promotional adjectives that vague over the concrete property
+they're praising. "What makes it 'amazing'? Replace with specifics."
+
+Example Rule Violations:
+    - "This is a wonderful, fantastic, mind-blowing release."
+      Stacked vague praise instead of any concrete property.
+    - "An amazing improvement in throughput."
+      Praise without a number or named property.
+
+Example Non-Violations:
+    - "Throughput rose 3.4x at the same p99 budget."
+      Concrete metric replaces the praise.
+    - "The release closed 12 long-standing data corruption bugs."
+      Names what changed without rhetorical inflation.
+
+Severity: Low per hit; cumulative use signals promotional rather than reported
+prose. Skips entries already covered by SlopWordRule (stunning, breathtaking,
+captivating).
+"""
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_ECSTATIC_TERMS: tuple[str, ...] = (
+    "wonderful",
+    "amazing",
+    "incredible",
+    "fantastic",
+    "phenomenal",
+    "magnificent",
+    "mind-blowing",
+    "awe-inspiring",
+)
+_ECSTATIC_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(term) for term in _ECSTATIC_TERMS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class EcstaticAdjectiveRuleConfig(RuleConfig):
+    """Config for ecstatic-adjective matching."""
+
+    penalty: int = field(
+        metadata={"description": ("Penalty applied per matched ecstatic adjective.")}
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each ecstatic-adjective violation."
+            )
+        }
+    )
+
+
+class EcstaticAdjectiveRule(Rule[EcstaticAdjectiveRuleConfig]):
+    """Record one violation per ecstatic high-praise adjective."""
+
+    name = "ecstatic_adjective"
+    count_key = "ecstatic_adjectives"
+    level = RuleLevel.WORD
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger ecstatic-adjective matches."""
+        return [
+            "This is a wonderful and fantastic release.",
+            "The result was mind-blowing.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid ecstatic-adjective matches."""
+        return [
+            "Throughput rose 3.4x at the same p99 budget.",
+            "The release closed 12 data corruption bugs.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each ecstatic adjective and emit one violation per hit."""
+        masked_text = document.text_with_markdown_code_masked
+        violations: list[Violation] = []
+        term_counts: Counter[str] = Counter()
+        advice_order: list[str] = []
+        for match in _ECSTATIC_RE.finditer(masked_text):
+            term = match.group(0).lower()
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match=term,
+                    context=context_around(
+                        document.text,
+                        match.start(),
+                        match.end(),
+                        width=self.config.context_window_chars,
+                    ),
+                    penalty=self.config.penalty,
+                    start=match.start(),
+                    end=match.end(),
+                )
+            )
+            if term_counts[term] == 0:
+                advice_order.append(term)
+            term_counts[term] += 1
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Cut '{term}' — name the concrete property, metric, or change."
+            for term in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> EcstaticAdjectiveRuleConfig:
+        """Fit penalty strength from observed ecstatic-adjective prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        positive_matches = sum(
+            1
+            for sample in positive_samples
+            if _ECSTATIC_RE.search(
+                AnalysisDocument.from_text(sample).text_with_markdown_code_masked
+            )
+            is not None
+        )
+        negative_matches = sum(
+            1
+            for sample in negative_samples
+            if _ECSTATIC_RE.search(
+                AnalysisDocument.from_text(sample).text_with_markdown_code_masked
+            )
+            is not None
+        )
+        return EcstaticAdjectiveRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/word/pretentious_word.py
+++ b/src/slop_guard/rules/word/pretentious_word.py
@@ -1,0 +1,177 @@
+"""Detect pretentious vocabulary with concrete plain-English replacements.
+
+Objective: Catch long words used where shorter ones do (Orwell's rule 2: never
+use a long word where a short one will do). Each entry carries the replacement
+so advice can recommend the specific substitution.
+
+Example Rule Violations:
+    - "We will utilize a new methodology."
+      Uses "utilize" where "use" is shorter and clearer.
+    - "Commence the aforementioned subsequent phase."
+      Stacks pretentious replacements for "start", "this", and "next".
+
+Example Non-Violations:
+    - "Use the next phase of the rollout."
+      Plain English equivalents.
+    - "The method runs in O(n)."
+      Domain term used precisely; no inflated synonym.
+
+Severity: Medium per hit; the replacement is usually a strict improvement.
+"""
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_PRETENTIOUS_REPLACEMENTS: tuple[tuple[str, str], ...] = (
+    ("utilize", "use"),
+    ("utilizes", "uses"),
+    ("utilized", "used"),
+    ("utilizing", "using"),
+    ("facilitate", "help"),
+    ("facilitates", "helps"),
+    ("facilitated", "helped"),
+    ("facilitating", "helping"),
+    ("commence", "start"),
+    ("commences", "starts"),
+    ("commenced", "started"),
+    ("commencing", "starting"),
+    ("subsequent", "next"),
+    ("subsequently", "later"),
+    ("methodology", "method"),
+    ("methodologies", "methods"),
+    ("ameliorate", "improve"),
+    ("aforementioned", "this"),
+    ("endeavor", "try"),
+    ("endeavors", "tries"),
+    ("endeavored", "tried"),
+)
+_PRETENTIOUS_BY_WORD: dict[str, str] = {
+    word.lower(): replacement for word, replacement in _PRETENTIOUS_REPLACEMENTS
+}
+_PRETENTIOUS_RE = re.compile(
+    r"\b(?:"
+    + "|".join(re.escape(word) for word, _ in _PRETENTIOUS_REPLACEMENTS)
+    + r")\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class PretentiousWordRuleConfig(RuleConfig):
+    """Config for pretentious-word matching with replacements."""
+
+    penalty: int = field(
+        metadata={"description": ("Penalty applied per matched pretentious word.")}
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each pretentious-word violation."
+            )
+        }
+    )
+
+
+class PretentiousWordRule(Rule[PretentiousWordRuleConfig]):
+    """Flag pretentious words and recommend the plain-English equivalent."""
+
+    name = "pretentious_word"
+    count_key = "pretentious_words"
+    level = RuleLevel.WORD
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger pretentious-word matches."""
+        return [
+            "We will utilize a new methodology.",
+            "Commence the aforementioned phase.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid pretentious-word matches."""
+        return [
+            "Use the next phase of the rollout.",
+            "The method runs in linear time.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each pretentious word and emit a replacement-aware violation."""
+        masked_text = document.text_with_markdown_code_masked
+        violations: list[Violation] = []
+        word_counts: Counter[str] = Counter()
+        advice_order: list[str] = []
+        for match in _PRETENTIOUS_RE.finditer(masked_text):
+            word = match.group(0).lower()
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match=word,
+                    context=context_around(
+                        document.text,
+                        match.start(),
+                        match.end(),
+                        width=self.config.context_window_chars,
+                    ),
+                    penalty=self.config.penalty,
+                    start=match.start(),
+                    end=match.end(),
+                )
+            )
+            if word_counts[word] == 0:
+                advice_order.append(word)
+            word_counts[word] += 1
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Replace '{word}' with '{_PRETENTIOUS_BY_WORD[word]}'."
+            for word in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> PretentiousWordRuleConfig:
+        """Fit penalty strength from pretentious-word prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        positive_matches = sum(
+            1
+            for sample in positive_samples
+            if _PRETENTIOUS_RE.search(
+                AnalysisDocument.from_text(sample).text_with_markdown_code_masked
+            )
+            is not None
+        )
+        negative_matches = sum(
+            1
+            for sample in negative_samples
+            if _PRETENTIOUS_RE.search(
+                AnalysisDocument.from_text(sample).text_with_markdown_code_masked
+            )
+            is not None
+        )
+        return PretentiousWordRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/rules/word/qualifier_word.py
+++ b/src/slop_guard/rules/word/qualifier_word.py
@@ -1,0 +1,161 @@
+"""Detect weakening qualifier words and phrases.
+
+Objective: Flag hedge qualifiers that drain specificity from claims (Twain:
+substitute "damn" every time you write "very" and let your editor delete it).
+
+Example Rule Violations:
+    - "The fix is very fast and quite reliable."
+      Stacks weakeners instead of citing concrete metrics.
+    - "It was sort of unclear what the impact was."
+      Uses a multi-word qualifier in place of a definite assessment.
+
+Example Non-Violations:
+    - "The patch reduced p99 latency from 400 ms to 90 ms."
+      Concrete measurement with no hedging.
+    - "Three retries succeeded; the fourth timed out."
+      Direct statement of outcome.
+
+Severity: Low per hit; cumulative penalty signals hedged or imprecise prose.
+"""
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+from slop_guard.document import AnalysisDocument, context_around
+from slop_guard.models import RuleResult, Violation
+from slop_guard.rules.base import Label, Rule, RuleConfig, RuleLevel
+from slop_guard.rules.fitting import fit_penalty_contrastive
+
+_QUALIFIER_TERMS: tuple[str, ...] = (
+    "very",
+    "quite",
+    "rather",
+    "somewhat",
+    "fairly",
+    "sort of",
+    "kind of",
+    "pretty much",
+    "a bit",
+)
+_QUALIFIER_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(term) for term in _QUALIFIER_TERMS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class QualifierWordRuleConfig(RuleConfig):
+    """Config for qualifier-word matching."""
+
+    penalty: int = field(
+        metadata={
+            "description": ("Penalty applied per matched qualifier-word occurrence.")
+        }
+    )
+    context_window_chars: int = field(
+        metadata={
+            "description": (
+                "Half-width (in characters) of the surrounding-text window "
+                "captured as context for each qualifier violation."
+            )
+        }
+    )
+
+
+class QualifierWordRule(Rule[QualifierWordRuleConfig]):
+    """Record a violation per qualifier word or short qualifier phrase."""
+
+    name = "qualifier_word"
+    count_key = "qualifier_words"
+    level = RuleLevel.WORD
+    category = "writing_quality"
+
+    def example_violations(self) -> list[str]:
+        """Return samples that should trigger qualifier-word matches."""
+        return [
+            "The fix is very fast and quite reliable.",
+            "It was sort of unclear what to do.",
+        ]
+
+    def example_non_violations(self) -> list[str]:
+        """Return samples that should avoid qualifier-word matches."""
+        return [
+            "The patch reduced p99 latency from 400 ms to 90 ms.",
+            "Three retries succeeded; the fourth timed out.",
+        ]
+
+    def forward(self, document: AnalysisDocument) -> RuleResult:
+        """Match each qualifier occurrence and emit one violation per hit."""
+        masked_text = document.text_with_markdown_code_masked
+        violations: list[Violation] = []
+        term_counts: Counter[str] = Counter()
+        advice_order: list[str] = []
+        for match in _QUALIFIER_RE.finditer(masked_text):
+            term = match.group(0).lower()
+            violations.append(
+                Violation(
+                    rule=self.name,
+                    match=term,
+                    context=context_around(
+                        document.text,
+                        match.start(),
+                        match.end(),
+                        width=self.config.context_window_chars,
+                    ),
+                    penalty=self.config.penalty,
+                    start=match.start(),
+                    end=match.end(),
+                )
+            )
+            if term_counts[term] == 0:
+                advice_order.append(term)
+            term_counts[term] += 1
+
+        if not violations:
+            return RuleResult()
+
+        advice = [
+            f"Cut '{term}' — be specific or remove the qualifier."
+            for term in advice_order
+        ]
+        return RuleResult(
+            violations=violations,
+            advice=advice,
+            count_deltas={self.count_key: len(violations)},
+        )
+
+    def _fit(
+        self, samples: list[str], labels: list[Label] | None
+    ) -> QualifierWordRuleConfig:
+        """Fit penalty strength from observed qualifier prevalence."""
+        positive_samples, negative_samples = self._split_fit_samples(samples, labels)
+        if not positive_samples:
+            return self.config
+
+        positive_matches = sum(
+            1
+            for sample in positive_samples
+            if _QUALIFIER_RE.search(
+                AnalysisDocument.from_text(sample).text_with_markdown_code_masked
+            )
+            is not None
+        )
+        negative_matches = sum(
+            1
+            for sample in negative_samples
+            if _QUALIFIER_RE.search(
+                AnalysisDocument.from_text(sample).text_with_markdown_code_masked
+            )
+            is not None
+        )
+        return QualifierWordRuleConfig(
+            penalty=fit_penalty_contrastive(
+                base_penalty=self.config.penalty,
+                positive_matches=positive_matches,
+                positive_total=len(positive_samples),
+                negative_matches=negative_matches,
+                negative_total=len(negative_samples),
+            ),
+            context_window_chars=self.config.context_window_chars,
+        )

--- a/src/slop_guard/scoring.py
+++ b/src/slop_guard/scoring.py
@@ -131,6 +131,8 @@ def serialize_violations(
     violations: Iterable[Violation],
     text: str,
     context_window_chars: int,
+    *,
+    include_category: bool = False,
 ) -> list[ViolationPayload]:
     """Serialize violations and attach resolved character offsets."""
     normalized_text = text.replace("\n", " ")
@@ -146,7 +148,9 @@ def serialize_violations(
             used_spans,
         )
         used_spans.add((start, end))
-        payloads.append(violation.to_payload(start, end))
+        payloads.append(
+            violation.to_payload(start, end, include_category=include_category)
+        )
 
     return payloads
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,167 @@
+"""Tests for rule-category tagging and category_counts aggregation.
+
+Each Rule subclass declares a ``category`` ("ai_slop" or "writing_quality").
+The pipeline tags every violation it emits with the producing rule's category,
+and the analyzer aggregates per-category counts into ``category_counts``.
+"""
+
+from importlib.resources import files
+
+from slop_guard.config import DEFAULT_HYPERPARAMETERS
+from slop_guard.document import AnalysisDocument
+from slop_guard.engine import analyze_text
+from slop_guard.rules import Pipeline
+from slop_guard.rules.catalog import (
+    DEFAULT_RULE_PATHS,
+    WRITING_QUALITY_RULE_PATHS,
+)
+from slop_guard.rules.registry import resolve_rule_type
+
+
+def _writing_quality_pipeline_path() -> str:
+    """Return the absolute path of the packaged writing_quality.jsonl."""
+    return str(files("slop_guard.rules").joinpath("assets/writing_quality.jsonl"))
+
+
+def test_default_pipeline_rules_are_tagged_ai_slop() -> None:
+    """All rules in the packaged default pipeline should carry category 'ai_slop'."""
+    pipeline = Pipeline.from_jsonl()
+    assert all(rule.category == "ai_slop" for rule in pipeline.rules)
+
+
+def test_writing_quality_pipeline_rules_are_tagged_writing_quality() -> None:
+    """All rules in writing_quality.jsonl should carry category 'writing_quality'."""
+    pipeline = Pipeline.from_jsonl(_writing_quality_pipeline_path())
+    assert all(rule.category == "writing_quality" for rule in pipeline.rules)
+
+
+def test_writing_quality_pipeline_includes_every_writing_quality_rule_class() -> None:
+    """writing_quality.jsonl should reference every WritingQuality rule path."""
+    pipeline = Pipeline.from_jsonl(_writing_quality_pipeline_path())
+    loaded_paths = {
+        f"{type(rule).__module__}.{type(rule).__name__}" for rule in pipeline.rules
+    }
+    assert loaded_paths == set(WRITING_QUALITY_RULE_PATHS)
+
+
+def test_default_paths_and_writing_quality_paths_are_disjoint() -> None:
+    """The two catalogs should partition the rule space — no overlap."""
+    assert set(DEFAULT_RULE_PATHS).isdisjoint(set(WRITING_QUALITY_RULE_PATHS))
+
+
+def test_default_pipeline_omits_category_fields_from_payload() -> None:
+    """Default ai_slop-only pipelines should not emit category/category_counts."""
+    text = (
+        "This is a crucial and groundbreaking paradigm that feels remarkably "
+        "innovative and comprehensive overall."
+    )
+
+    result = analyze_text(text, hyperparameters=DEFAULT_HYPERPARAMETERS)
+
+    assert result["violations"], "expected at least one violation in this text"
+    assert "category_counts" not in result
+    assert all("category" not in violation for violation in result["violations"])
+
+
+def test_writing_quality_pipeline_violations_carry_writing_quality_category() -> None:
+    """Violations emitted by the writing_quality pipeline should be tagged."""
+    pipeline = Pipeline.from_jsonl(_writing_quality_pipeline_path())
+    text = (
+        "It is obvious that we should utilize the methodology in order to "
+        "move the needle on the end result."
+    )
+
+    result = analyze_text(
+        text, hyperparameters=DEFAULT_HYPERPARAMETERS, pipeline=pipeline
+    )
+
+    assert result["violations"], "expected at least one violation in this text"
+    assert all(
+        violation["category"] == "writing_quality" for violation in result["violations"]
+    )
+
+
+def test_category_counts_aggregates_violations_per_category() -> None:
+    """category_counts should sum to total violation count per category."""
+    pipeline = Pipeline.from_jsonl(_writing_quality_pipeline_path())
+    text = (
+        "It is obvious that we should utilize the methodology in order to "
+        "move the needle on the end result."
+    )
+
+    result = analyze_text(
+        text, hyperparameters=DEFAULT_HYPERPARAMETERS, pipeline=pipeline
+    )
+
+    total_counted = sum(result["category_counts"].values())
+    assert total_counted == len(result["violations"])
+    assert result["category_counts"]["writing_quality"] == len(result["violations"])
+
+
+def test_category_counts_handles_mixed_pipelines() -> None:
+    """Mixed pipelines should produce category_counts with both categories."""
+    default_rules = list(Pipeline.from_jsonl().rules)
+    writing_rules = list(Pipeline.from_jsonl(_writing_quality_pipeline_path()).rules)
+    mixed_pipeline = Pipeline(default_rules + writing_rules)
+    text = (
+        "This crucial paradigm is groundbreaking. "
+        "It is obvious that we should utilize the methodology."
+    )
+
+    result = analyze_text(
+        text, hyperparameters=DEFAULT_HYPERPARAMETERS, pipeline=mixed_pipeline
+    )
+
+    assert "ai_slop" in result["category_counts"]
+    assert "writing_quality" in result["category_counts"]
+    assert result["category_counts"]["ai_slop"] + result["category_counts"][
+        "writing_quality"
+    ] == len(result["violations"])
+
+
+def test_category_counts_empty_when_writing_quality_pipeline_has_no_hits() -> None:
+    """Writing_quality pipeline on clean text should still emit (empty) category_counts."""
+    pipeline = Pipeline.from_jsonl(_writing_quality_pipeline_path())
+    text = (
+        "The patch reduced p99 latency from 400 ms to 90 ms. "
+        "Three retries succeeded; the fourth timed out. "
+        "Cache hit rate stayed at 92% across the rollout window."
+    )
+
+    result = analyze_text(
+        text, hyperparameters=DEFAULT_HYPERPARAMETERS, pipeline=pipeline
+    )
+
+    assert result["category_counts"] == {}
+
+
+def test_writing_quality_rule_classes_carry_category_attribute() -> None:
+    """Each writing_quality Rule class should declare category='writing_quality'."""
+    for rule_path in WRITING_QUALITY_RULE_PATHS:
+        rule_type = resolve_rule_type(rule_path)
+        assert rule_type.category == "writing_quality", (
+            f"{rule_path} missing category='writing_quality'"
+        )
+
+
+def test_default_rule_classes_carry_ai_slop_category() -> None:
+    """Each default Rule class should declare (or inherit) category='ai_slop'."""
+    for rule_path in DEFAULT_RULE_PATHS:
+        rule_type = resolve_rule_type(rule_path)
+        assert rule_type.category == "ai_slop", (
+            f"{rule_path} category should be 'ai_slop'"
+        )
+
+
+def test_pipeline_tagging_does_not_mutate_rule_emitted_violations() -> None:
+    """Pipeline tagging should produce new Violation instances, not mutate originals."""
+    pipeline = Pipeline.from_jsonl(_writing_quality_pipeline_path())
+    document = AnalysisDocument.from_text(
+        "It is obvious that we should utilize the methodology."
+    )
+
+    state = pipeline.forward(document)
+
+    assert all(
+        violation.category == "writing_quality" for violation in state.violations
+    )

--- a/tests/test_opinionated_rules.py
+++ b/tests/test_opinionated_rules.py
@@ -1,0 +1,413 @@
+"""Targeted tests for the opinionated writing rules.
+
+The generic framework test in ``test_rule_framework.py`` already exercises each
+rule's ``example_violations`` and ``example_non_violations``. These tests cover
+the rule-specific behaviors the generic test cannot: replacement-aware advice,
+cap enforcement, density thresholds, the passive-voice tier-two gate, and the
+fit paths.
+"""
+
+from slop_guard.document import AnalysisDocument
+from slop_guard.rules.paragraph.narrative_heading import (
+    NarrativeHeadingRule,
+    NarrativeHeadingRuleConfig,
+)
+from slop_guard.rules.passage.emoji_in_prose import (
+    EmojiInProseRule,
+    EmojiInProseRuleConfig,
+)
+from slop_guard.rules.passage.exclamation_density import (
+    ExclamationDensityRule,
+    ExclamationDensityRuleConfig,
+)
+from slop_guard.rules.passage.long_sentence import (
+    LongSentenceRule,
+    LongSentenceRuleConfig,
+)
+from slop_guard.rules.sentence.cliche_phrase import (
+    ClichePhraseRule,
+    ClichePhraseRuleConfig,
+)
+from slop_guard.rules.sentence.foreign_phrase import (
+    ForeignPhraseRule,
+    ForeignPhraseRuleConfig,
+)
+from slop_guard.rules.sentence.over_explanation import (
+    OverExplanationRule,
+    OverExplanationRuleConfig,
+)
+from slop_guard.rules.sentence.passive_voice import (
+    PassiveVoiceRule,
+    PassiveVoiceRuleConfig,
+)
+from slop_guard.rules.sentence.redundant_pair import (
+    RedundantPairRule,
+    RedundantPairRuleConfig,
+)
+from slop_guard.rules.sentence.throat_clearing import (
+    ThroatClearingRule,
+    ThroatClearingRuleConfig,
+)
+from slop_guard.rules.sentence.verbose_phrase import (
+    VerbosePhraseRule,
+    VerbosePhraseRuleConfig,
+)
+from slop_guard.rules.word.ecstatic_adjective import (
+    EcstaticAdjectiveRule,
+    EcstaticAdjectiveRuleConfig,
+)
+from slop_guard.rules.word.pretentious_word import (
+    PretentiousWordRule,
+    PretentiousWordRuleConfig,
+)
+from slop_guard.rules.word.qualifier_word import (
+    QualifierWordRule,
+    QualifierWordRuleConfig,
+)
+
+
+def _doc(text: str) -> AnalysisDocument:
+    """Return an AnalysisDocument for ``text``."""
+    return AnalysisDocument.from_text(text)
+
+
+# Replacements -----------------------------------------------------------------
+
+
+def test_verbose_phrase_advice_cites_concise_replacement() -> None:
+    """Verbose-phrase advice should name the concise replacement."""
+    rule = VerbosePhraseRule(
+        VerbosePhraseRuleConfig(penalty=-2, context_window_chars=60)
+    )
+    result = rule.forward(_doc("We migrated in order to reduce cost."))
+    assert any("'in order to'" in line and "'to'" in line for line in result.advice)
+
+
+def test_pretentious_word_advice_cites_plain_replacement() -> None:
+    """Pretentious-word advice should name the plain-English replacement."""
+    rule = PretentiousWordRule(
+        PretentiousWordRuleConfig(penalty=-2, context_window_chars=60)
+    )
+    result = rule.forward(_doc("We will utilize the new approach."))
+    assert any("'utilize'" in line and "'use'" in line for line in result.advice)
+
+
+def test_foreign_phrase_advice_cites_plain_replacement() -> None:
+    """Foreign-phrase advice should name the plain-English replacement."""
+    rule = ForeignPhraseRule(
+        ForeignPhraseRuleConfig(penalty=-1, context_window_chars=60)
+    )
+    result = rule.forward(_doc("Per se, the rollout was successful."))
+    assert any("'per se'" in line and "'by itself'" in line for line in result.advice)
+
+
+# Cap and threshold semantics --------------------------------------------------
+
+
+def test_long_sentence_rule_honors_max_hits_cap() -> None:
+    """Long-sentence rule should never emit more than max_hits violations."""
+    rule = LongSentenceRule(LongSentenceRuleConfig(min_words=5, max_hits=2, penalty=-2))
+    long_sentence = " ".join(["alpha"] * 6) + "."
+    text = (long_sentence + " ") * 5
+    result = rule.forward(_doc(text))
+    assert len(result.violations) == 2
+
+
+def test_passive_voice_tier_two_gate_requires_min_hits() -> None:
+    """Tier-two density should not fire below the configured minimum."""
+    rule = PassiveVoiceRule(
+        PassiveVoiceRuleConfig(penalty=-2, tier_two_min_hits=3, context_window_chars=60)
+    )
+
+    below_threshold = _doc("The migration is approved. The release is shipped.")
+    assert rule.forward(below_threshold).violations == []
+
+    at_threshold = _doc(
+        "The migration is approved. The release is shipped. Logs are dropped."
+    )
+    assert len(rule.forward(at_threshold).violations) >= 3
+
+
+def test_passive_voice_tier_one_fires_per_instance() -> None:
+    """Tier-one 'was X by' pattern should fire on every match without gating."""
+    rule = PassiveVoiceRule(
+        PassiveVoiceRuleConfig(
+            penalty=-2, tier_two_min_hits=99, context_window_chars=60
+        )
+    )
+    result = rule.forward(_doc("The plan was approved by the council."))
+    assert len(result.violations) == 1
+
+
+def test_exclamation_density_under_threshold_does_not_fire() -> None:
+    """Sub-threshold exclamation density should not emit violations."""
+    rule = ExclamationDensityRule(
+        ExclamationDensityRuleConfig(
+            words_basis=150.0, density_threshold=1.0, penalty=-3
+        )
+    )
+    text = " ".join(["word"] * 200) + "!"
+    assert rule.forward(_doc(text)).violations == []
+
+
+def test_exclamation_density_over_threshold_fires_once() -> None:
+    """Above-threshold exclamation density should emit exactly one violation."""
+    rule = ExclamationDensityRule(
+        ExclamationDensityRuleConfig(
+            words_basis=150.0, density_threshold=1.0, penalty=-3
+        )
+    )
+    text = "Wow! Yes! Indeed! Amazing!"
+    result = rule.forward(_doc(text))
+    assert len(result.violations) == 1
+
+
+# Per-instance match emission --------------------------------------------------
+
+
+def test_emoji_in_prose_emits_one_violation_per_emoji() -> None:
+    """Emoji rule should emit one violation per emoji character matched."""
+    rule = EmojiInProseRule(EmojiInProseRuleConfig(penalty=-3, context_window_chars=60))
+    result = rule.forward(
+        _doc("We shipped \U0001f680 and the team is happy \U0001f389.")
+    )
+    assert len(result.violations) == 2
+
+
+def test_qualifier_word_matches_multi_word_phrases() -> None:
+    """Qualifier rule should match multi-word qualifiers like 'sort of'."""
+    rule = QualifierWordRule(
+        QualifierWordRuleConfig(penalty=-1, context_window_chars=60)
+    )
+    result = rule.forward(_doc("The result was sort of unclear and a bit late."))
+    matches = {violation.match for violation in result.violations}
+    assert "sort of" in matches
+    assert "a bit" in matches
+
+
+def test_ecstatic_adjective_matches_hyphenated_terms() -> None:
+    """Ecstatic-adjective rule should match hyphenated terms like 'mind-blowing'."""
+    rule = EcstaticAdjectiveRule(
+        EcstaticAdjectiveRuleConfig(penalty=-1, context_window_chars=60)
+    )
+    result = rule.forward(_doc("The change was mind-blowing."))
+    assert any(violation.match == "mind-blowing" for violation in result.violations)
+
+
+def test_narrative_heading_matches_markdown_heading_at_any_depth() -> None:
+    """Narrative-heading rule should match `##`, `###`, etc. equally."""
+    rule = NarrativeHeadingRule(
+        NarrativeHeadingRuleConfig(penalty=-4, context_window_chars=60)
+    )
+    text = "# The Power of caching\n\n### The Art of Indexes\n\nbody text"
+    result = rule.forward(_doc(text))
+    assert len(result.violations) == 2
+
+
+def test_redundant_pair_matches_word_boundary() -> None:
+    """Redundant-pair rule should require word-boundary matches."""
+    rule = RedundantPairRule(
+        RedundantPairRuleConfig(penalty=-1, context_window_chars=60)
+    )
+    result = rule.forward(_doc("The end result was clear."))
+    assert any(violation.match == "end result" for violation in result.violations)
+
+
+def test_cliche_phrase_emits_advice_naming_phrase() -> None:
+    """Cliché advice should name the matched phrase explicitly."""
+    rule = ClichePhraseRule(ClichePhraseRuleConfig(penalty=-2, context_window_chars=60))
+    result = rule.forward(_doc("Let's think outside the box."))
+    assert any("think outside the box" in line for line in result.advice)
+
+
+def test_throat_clearing_advice_names_phrase() -> None:
+    """Throat-clearing advice should name the matched phrase explicitly."""
+    rule = ThroatClearingRule(
+        ThroatClearingRuleConfig(penalty=-2, context_window_chars=60)
+    )
+    result = rule.forward(_doc("Truth be told, the cache is unused."))
+    assert any("truth be told" in line for line in result.advice)
+
+
+def test_over_explanation_advice_names_phrase() -> None:
+    """Over-explanation advice should name the matched phrase explicitly."""
+    rule = OverExplanationRule(
+        OverExplanationRuleConfig(penalty=-2, context_window_chars=60)
+    )
+    result = rule.forward(_doc("Needless to say, retries should be idempotent."))
+    assert any("needless to say" in line for line in result.advice)
+
+
+# Fit paths --------------------------------------------------------------------
+
+
+def test_qualifier_word_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = QualifierWordRule(
+        QualifierWordRuleConfig(penalty=-1, context_window_chars=60)
+    )
+    fitted = rule.fit(["The fix is very fast.", "Throughput rose 3.4x."], [1, 0])
+    assert fitted is rule
+
+
+def test_pretentious_word_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = PretentiousWordRule(
+        PretentiousWordRuleConfig(penalty=-2, context_window_chars=60)
+    )
+    fitted = rule.fit(["Utilize the new method.", "Use the new method."], [1, 0])
+    assert fitted is rule
+
+
+def test_ecstatic_adjective_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = EcstaticAdjectiveRule(
+        EcstaticAdjectiveRuleConfig(penalty=-1, context_window_chars=60)
+    )
+    fitted = rule.fit(["A wonderful release.", "A 12% throughput gain."], [1, 0])
+    assert fitted is rule
+
+
+def test_verbose_phrase_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = VerbosePhraseRule(
+        VerbosePhraseRuleConfig(penalty=-2, context_window_chars=60)
+    )
+    fitted = rule.fit(
+        ["We migrated in order to reduce cost.", "We migrated to reduce cost."],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_throat_clearing_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = ThroatClearingRule(
+        ThroatClearingRuleConfig(penalty=-2, context_window_chars=60)
+    )
+    fitted = rule.fit(
+        ["Truth be told, retries are needed.", "Retries are needed."],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_over_explanation_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = OverExplanationRule(
+        OverExplanationRuleConfig(penalty=-2, context_window_chars=60)
+    )
+    fitted = rule.fit(
+        ["Needless to say, x.", "x."],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_redundant_pair_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = RedundantPairRule(
+        RedundantPairRuleConfig(penalty=-1, context_window_chars=60)
+    )
+    fitted = rule.fit(
+        ["The end result is x.", "The result is x."],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_cliche_phrase_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = ClichePhraseRule(ClichePhraseRuleConfig(penalty=-2, context_window_chars=60))
+    fitted = rule.fit(
+        ["Let's think outside the box.", "Let's batch writes."],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_foreign_phrase_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = ForeignPhraseRule(
+        ForeignPhraseRuleConfig(penalty=-1, context_window_chars=60)
+    )
+    fitted = rule.fit(
+        ["Per se, the change is fine.", "By itself, the change is fine."],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_passive_voice_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = PassiveVoiceRule(
+        PassiveVoiceRuleConfig(penalty=-2, tier_two_min_hits=3, context_window_chars=60)
+    )
+    fitted = rule.fit(
+        [
+            "The plan was approved by the council.",
+            "The council approved the plan.",
+        ],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_long_sentence_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = LongSentenceRule(LongSentenceRuleConfig(min_words=5, max_hits=5, penalty=-2))
+    long_sample = " ".join(["alpha"] * 8) + "."
+    short_sample = "alpha. beta."
+    fitted = rule.fit([long_sample, short_sample], [1, 0])
+    assert fitted is rule
+
+
+def test_exclamation_density_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = ExclamationDensityRule(
+        ExclamationDensityRuleConfig(
+            words_basis=10.0, density_threshold=0.0, penalty=-3
+        )
+    )
+    fitted = rule.fit(["Wow! Yes! Amazing!", "Wow. Yes. Amazing."], [1, 0])
+    assert fitted is rule
+
+
+def test_emoji_in_prose_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = EmojiInProseRule(EmojiInProseRuleConfig(penalty=-3, context_window_chars=60))
+    fitted = rule.fit(
+        ["We shipped it \U0001f680.", "We shipped it."],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_narrative_heading_fit_returns_self() -> None:
+    """Fit should return self after fitting and apply penalty changes."""
+    rule = NarrativeHeadingRule(
+        NarrativeHeadingRuleConfig(penalty=-4, context_window_chars=60)
+    )
+    fitted = rule.fit(
+        ["## The Journey of Caching", "## Caching strategy"],
+        [1, 0],
+    )
+    assert fitted is rule
+
+
+def test_long_sentence_fit_returns_unchanged_with_no_positive_samples() -> None:
+    """Fit on no positives should return existing config unchanged."""
+    rule = LongSentenceRule(LongSentenceRuleConfig(min_words=5, max_hits=5, penalty=-2))
+    rule.fit([], [])
+    assert rule.config.penalty == -2
+
+
+def test_exclamation_density_fit_handles_empty_positive_ratios() -> None:
+    """Fit should keep config when no positive sample yields a valid ratio."""
+    rule = ExclamationDensityRule(
+        ExclamationDensityRuleConfig(
+            words_basis=150.0, density_threshold=1.0, penalty=-3
+        )
+    )
+    rule.fit(["", ""], [1, 0])
+    assert rule.config.density_threshold == 1.0

--- a/tools/docs_rules.py
+++ b/tools/docs_rules.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, TypeAlias
 
 from slop_guard.rules.base import Rule
-from slop_guard.rules.catalog import DEFAULT_RULE_PATHS
+from slop_guard.rules.catalog import ALL_RULE_PATHS, DEFAULT_RULE_PATHS
 
 RulePath: TypeAlias = str
 ConfigMap: TypeAlias = dict[str, Any]
@@ -140,19 +140,24 @@ class RuleDoc:
 
 
 def _load_default_configs() -> dict[str, ConfigMap]:
-    """Return default config dicts keyed by the fully-qualified rule path."""
-    raw_text = (
-        files("slop_guard.rules")
-        .joinpath("assets/default.jsonl")
-        .read_text(encoding="utf-8")
-    )
+    """Return default config dicts keyed by the fully-qualified rule path.
+
+    Reads every packaged preset JSONL so each rule's seeded config can be
+    surfaced on its docs page, regardless of which preset registers it.
+    """
     configs: dict[str, ConfigMap] = {}
-    for line in raw_text.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        payload = json.loads(stripped)
-        configs[payload["rule_type"]] = dict(payload["config"])
+    for asset_name in ("default.jsonl", "writing_quality.jsonl"):
+        raw_text = (
+            files("slop_guard.rules")
+            .joinpath(f"assets/{asset_name}")
+            .read_text(encoding="utf-8")
+        )
+        for line in raw_text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            payload = json.loads(stripped)
+            configs[payload["rule_type"]] = dict(payload["config"])
     return configs
 
 
@@ -547,6 +552,8 @@ def render_index_page(docs: list[RuleDoc]) -> str:
     """Render the rule library overview page with per-level card grids."""
     groups = _group_by_level(docs)
     total = len(docs)
+    default_count = sum(1 for doc in docs if doc.dotted_path in DEFAULT_RULE_PATHS)
+    optional_count = total - default_count
     header = [
         "---",
         "icon: lucide/list-checks",
@@ -560,7 +567,9 @@ def render_index_page(docs: list[RuleDoc]) -> str:
         "Each rule targets one formulaic pattern, flags the exact matching "
         "spans, and contributes a penalty toward the final score.",
         "",
-        f"The default pipeline runs **{total} rules** across four scopes. "
+        f"The library lists **{total} rules** across four scopes — "
+        f"**{default_count}** in the default `ai_slop` pipeline and "
+        f"**{optional_count}** in the opt-in `writing_quality` preset. "
         "Open a card to read the full rule page, including example "
         "violations, default thresholds, and a link to the source file.",
         "",
@@ -590,9 +599,14 @@ def _reset_output_dir(output_dir: Path) -> None:
 
 
 def build_rule_docs() -> list[RuleDoc]:
-    """Return parsed rule docs for every rule in the default catalog."""
+    """Return parsed rule docs for every rule in the catalog.
+
+    Includes both the default ``ai_slop`` preset and the opt-in
+    ``writing_quality`` preset so each registered rule gets a generated
+    page.
+    """
     defaults = _load_default_configs()
-    return [_load_rule_doc(path, defaults) for path in DEFAULT_RULE_PATHS]
+    return [_load_rule_doc(path, defaults) for path in ALL_RULE_PATHS]
 
 
 def nav_entries(docs: list[RuleDoc]) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Description

This PR adds the new pipeline registers fourteen opinionated writing rules from issue #9: qualifier words, verbose phrases, pretentious vocabulary with replacements, redundant pairs, clichés, foreign and Latin phrases, and ecstatic adjectives. The pipeline also flags throat-clearing, over-explanation, two-tier passive voice, sentences over 40 words, exclamation density, emoji in prose, and narrative-poetic Markdown headings. 

Every Rule subclass now carries a `category` class attribute (`ai_slop` or `writing_quality`). The pipeline tags each emitted violation with the producing rule's category, and the analyzer aggregates per-category counts into a new `category_counts` field. Both extras are emitted only when the active pipeline includes a non-default category, so default-only output stays byte-shape-identical to `main`.

## Why?

I was looking for a way to scrub passive voice out of long-form drafts and ran into this feature request If there's interest in merging this upstream, I will iter iterate on feedback. If not, I can make the fork at [mlgill/slop-guard](https://github.com/mlgill/slop-guard) private and maintain the writing-quality presets there. Let me know which direction you prefer.

## Usage / Demonstration

The default `ai_slop` preset is unchanged and still loads automatically:

```bash
sg draft.md
```

The writing-quality preset is opt-in via the existing `-c` flag. Resolve the bundled path:

```bash
WQ=$(python -c 'from importlib.resources import files; print(files("slop_guard.rules").joinpath("assets/writing_quality.jsonl"))')
sg -c "$WQ" draft.md
```

Run both together by concatenating the JSONL files:

```bash
DEF=$(python -c 'from importlib.resources import files; print(files("slop_guard.rules").joinpath("assets/default.jsonl"))')
cat "$DEF" "$WQ" > all_rules.jsonl
sg -c all_rules.jsonl draft.md
```

Real example, both presets active on a 20-word sample:

```text
This crucial paradigm is groundbreaking. It is obvious that we should
utilize the methodology in order to move the needle.
```

```
sample.md: 0/100 [saturated] (20 words)
  slop_word: crucial (-2)
  slop_word: paradigm (-2)
  slop_word: groundbreaking (-2)
  pretentious_word: utilize (-2)
  pretentious_word: methodology (-2)
  verbose_phrase: in order to (-2)
  over_explanation: it is obvious that (-2)
  cliche_phrase: move the needle (-2)
  - Replace 'utilize' with 'use'.
  - Replace 'methodology' with 'method'.
  - Replace 'in order to' with 'to'.
  - Cut 'it is obvious that' — state the claim without prefacing it as obvious.
  - Cut 'move the needle' — name the concrete idea the cliché stands in for.
```

The same run via JSON includes the category aggregation:

```json
{
  "score": 0,
  "category_counts": {"ai_slop": 3, "writing_quality": 5},
  "violations": [
    {"rule": "slop_word", "category": "ai_slop", "match": "crucial", ...},
    {"rule": "pretentious_word", "category": "writing_quality", "match": "utilize", ...}
  ]
}
```

When only the default `ai_slop` preset runs, neither `category` nor `category_counts` appears — the JSON shape matches the pre-PR release exactly.

## Verification

- `make check` passes: 226 tests, ruff format and lint clean, ty type-check clean, 83.18% coverage (above the 80% gate).
- 32 new targeted tests in `tests/test_opinionated_rules.py` covering replacement-aware advice, the long-sentence cap, the passive-voice tier-two density gate, exclamation-density threshold, per-emoji emission, hyphenated and multi-word matching, and fit paths for every new rule.
- 12 category tests in `tests/test_categories.py` covering both directions of tagging, mixed pipelines, conditional `category_counts` emission, and disjoint catalog partitioning.
- Smoke-tested both presets via `sg -j` and `sg -v` on the same input. Default JSON output verified to match `main` byte-for-byte (no `category` keys, no `category_counts`).
- Generated `docs/rules/*.md` pages for the fourteen new rules via `make docs-rules`. The 24 existing rule pages are untouched.
- Self-linted `README.md`, `docs/get-started.md`, and `docs/agents.md` against both presets; all score in the clean band except a few honest hits where the prose literally cites the phrases its own rules flag.

## Issues

- Closes #9.
